### PR TITLE
enable sign in via OAuth2 token

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,4 @@ indent_size=2
 [*.{js,jsx}]
 indent_style=space
 indent_size=2
+max_line_length=99

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ To build for production:
 To run the tests:
 
 `npm test`
+
+To serve some documentation on the components
+
+`npm run styleguide`

--- a/package.json
+++ b/package.json
@@ -6,16 +6,25 @@
     "material-ui": "^0.20.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-redux": "^5.0.6",
+    "react-router-dom": "4.2.2",
     "react-scripts": "1.1.0",
-    "react-router-dom": "4.2.2"
+    "redux": "^3.7.2",
+    "redux-implicit-oauth2": "^1.2.1",
+    "redux-logger": "^3.0.6"
   },
   "devDependencies": {
-    "react-test-renderer": "16"
+    "mock-local-storage": "^1.0.5",
+    "react-styleguidist": "^6.2.0",
+    "react-test-renderer": "16",
+    "redux-mock-store": "^1.5.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom --coverage",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "styleguide": "styleguidist server",
+    "styleguide:build": "styleguidist build"
   }
 }

--- a/src/components/LoginButton.js
+++ b/src/components/LoginButton.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { RaisedButton } from 'material-ui';
+import { login, logout } from '../redux/actions';
+
+/**
+ * A material button which indicates the current sign in state and allows the user to log in or
+ * out.
+ */
+const LoginButton = ({ isLoggedIn, login, logout }) => {
+  if (isLoggedIn) {
+    return <RaisedButton type='RaisedButton' onClick={logout}>Sign Out</RaisedButton>
+  } else {
+    return <RaisedButton type='RaisedButton' onClick={login}>Sign In</RaisedButton>
+  }
+};
+
+LoginButton.propTypes = {
+  isLoggedIn: PropTypes.bool.isRequired,
+  login: PropTypes.func.isRequired,
+  logout: PropTypes.func.isRequired
+};
+
+const mapStateToProps = ({ auth }) => ({
+  isLoggedIn: auth.isLoggedIn
+});
+
+const mapDispatchToProps = { login, logout };
+
+export default connect(mapStateToProps, mapDispatchToProps)(LoginButton);

--- a/src/components/LoginRequiredRoute.js
+++ b/src/components/LoginRequiredRoute.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Route } from 'react-router-dom';
+import LoginPage from '../containers/LoginPage';
+
+export const DEFAULT_IF_LOGGED_OUT = <LoginPage />;
+
+/**
+ * A Route-alike which requires that a user be logged in. If the user is not logged in then a
+ * fallback component specified by the componentIfLoggedOut prop is rendered. If this prop is not
+ * given then the DEFAULT_IF_LOGGED_OUT component exported from this module is used.
+ *
+ * Based on https://reacttraining.com/react-router/web/example/auth-workflow
+ */
+const LoginRequiredRoute = ({
+  isLoggedIn,
+  component: Component,
+  componentIfLoggedOut = DEFAULT_IF_LOGGED_OUT,
+  ...rest
+}) => (
+  <Route {...rest} render={props => (
+    isLoggedIn ? (
+      <Component {...props} />
+    ) : (
+      DEFAULT_IF_LOGGED_OUT
+    )
+  )}/>
+);
+
+LoginRequiredRoute.propTypes = {
+  /** Is the user logged in or not? This prop is automatically connected to the auth.isLoggedIn
+   * value in the store. */
+  isLoggedIn: PropTypes.bool.isRequired,
+  /** The component to render if the route matches *and* the user is logged out. */
+  componentIfLoggedOut: PropTypes.element,
+}
+
+/**
+ * State mapping for LoginRequiredRoute component.
+ *
+ * It is assumed that the global state has an auth.isLoggedIn boolean which reflects the current
+ * login state. This is mapped to the isLoggedIn prop of LoginRequiredRoute.
+ */
+const mapStateToProps = ({ auth }) => ({
+  isLoggedIn: auth.isLoggedIn
+});
+
+export default connect(mapStateToProps)(LoginRequiredRoute);

--- a/src/components/LogoutLink.js
+++ b/src/components/LogoutLink.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { logout } from '../redux/actions';
+
+/**
+ * A link whose action will always log the current user out.
+ */
+const LogoutLink = ({logout, children, ...rest}) => (
+  // eslint-disable-next-line
+  <a href="#" onClick={logout} {...rest}>{ children }</a>
+);
+
+LogoutLink.propTypes = {
+  /** Function which dispatches a logout action. Automatically wired up to the logout action. */
+  logout: PropTypes.func.isRequired
+};
+
+const mapDispatchToProps = { logout };
+
+export default connect(null, mapDispatchToProps)(LogoutLink);

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import Drawer from 'material-ui/Drawer'
 import logo from '../images/logo.svg'
 import '../style/App.css'
+import LogoutLink from './LogoutLink';
 
 /*
   Renders the IAR application side bar.
@@ -21,6 +22,7 @@ const Sidebar = () => (
       <li><Link to="/static/feedback">Feedback</Link></li>
       <li><Link to="/static/contact">Contact</Link></li>
       <li><Link to="/static/tcs">Terms & Conditions</Link></li>
+      <li><LogoutLink>Sign out</LogoutLink></li>
     </ul>
   </Drawer>
 );

--- a/src/components/Static.js
+++ b/src/components/Static.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AppBar } from 'material-ui';
 import '../style/App.css';
+import Page from '../containers/Page';
 
 const TITLES = {
   '/static/what-is-asset': 'What is an information asset?',
@@ -23,12 +24,14 @@ const StaticHeader = ({ title }) => (
   Renders the IAR app's static pages.
  */
 const Static = ({ match }) => (
-  <div className="App-main">
-    <StaticHeader title={ TITLES[match.url] } />
+  <Page>
     <div>
-      <h1>Copy for "{ TITLES[match.url] }"</h1>
+      <StaticHeader title={ TITLES[match.url] } />
+      <div>
+        <h1>Copy for "{ TITLES[match.url] }"</h1>
+      </div>
     </div>
-  </div>
+  </Page>
 );
 
 export default Static;

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,27 +1,36 @@
-import React from 'react'
-import { BrowserRouter as Router, Route, Redirect } from 'react-router-dom'
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
-import Sidebar from '../components/Sidebar'
-import AssetList from './AssetList'
-import AssetForm from './AssetForm'
-import Static from '../components/Static'
-import '../style/App.css'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Provider } from 'react-redux';
+import { BrowserRouter as Router, Route, Redirect, Switch } from 'react-router-dom';
+import LoginRequiredRoute from '../components/LoginRequiredRoute';
 
-/*
-  IAR main app component.
-  */
-const App = () => (
-  <Router>
-    <MuiThemeProvider>
-      <div>
-        <Sidebar />
-        <Route path="/" exact render={() => <Redirect to="/assets/dept"/>} />
-        <Route path="/assets/:filter" component={AssetList} />
-        <Route path="/static/:page" component={Static} />
-        <Route path="/asset/:asset" component={AssetForm} />
-      </div>
-    </MuiThemeProvider>
-  </Router>
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import AssetList from './AssetList';
+import AssetForm from './AssetForm';
+import Static from '../components/Static';
+
+import '../style/App.css';
+
+/**
+ * IAR main application component.
+ */
+const App = ({ store }) => (
+  <Provider store={ store }>
+    <Router>
+      <MuiThemeProvider>
+        <Switch>
+          <Route path="/" exact render={() => <Redirect to="/assets/dept"/>} />
+          <LoginRequiredRoute path="/assets/:filter" component={AssetList} />
+          <LoginRequiredRoute path="/static/:page" component={Static} />
+          <LoginRequiredRoute path="/asset/:asset" component={AssetForm} />
+        </Switch>
+      </MuiThemeProvider>
+    </Router>
+  </Provider>
 );
 
-export default App
+App.propTypes = {
+  store: PropTypes.object.isRequired
+};
+
+export default App;

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -23,6 +23,7 @@ const App = ({ store }) => (
           <LoginRequiredRoute path="/assets/:filter" component={AssetList} />
           <LoginRequiredRoute path="/static/:page" component={Static} />
           <LoginRequiredRoute path="/asset/:asset" component={AssetForm} />
+          <Route path="/oauth2-callback" exact render={() => <div />} />
         </Switch>
       </MuiThemeProvider>
     </Router>

--- a/src/containers/App.test.js
+++ b/src/containers/App.test.js
@@ -1,9 +1,12 @@
+import '../test/mock-localstorage.js';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
+import { mockStore, DEFAULT_INITIAL_STATE } from '../testutils.js';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
+  ReactDOM.render(<App store={mockStore(DEFAULT_INITIAL_STATE)} />, div);
   ReactDOM.unmountComponentAtNode(div);
 });

--- a/src/containers/AssetForm.js
+++ b/src/containers/AssetForm.js
@@ -1,16 +1,17 @@
 import React from 'react'
 import AssetFormHeader from '../components/AssetFormHeader'
+import Page from '../containers/Page';
 
 /*
   Renders the form for the creation/editing of an Asset.
   */
 const AssetForm = ({ match }) => (
-  <div className="App-main">
+  <Page>
     <AssetFormHeader title={match.url === '/asset/create' ? 'Create new asset' : 'Editing: Some asset'} />
     <div>
       <h1>Asset Creation/Editing Form</h1>
     </div>
-  </div>
+  </Page>
 );
 
 export default AssetForm

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -10,58 +10,59 @@ import {
 import AssetListItem from '../components/AssetListItem';
 import AssetListHeader from '../components/AssetListHeader'
 import '../style/App.css';
+import Page from '../containers/Page';
 
 // Mock data until we can fetch data from the api
 const assetData = [
-	{
-		name: 'Asset #1',
-		status: 'In-progress',
-		department: 'UIS',
-		private: true,
-		lastedited: 'today'
-	},
-	{
-		name: 'Asset #2',
-		status: 'In-progress',
-		department: 'UIS',
-		private: true,
-		lastedited: 'today'
-	},
-	{
-		name: 'Asset #3',
-		status: 'Complete',
-		department: 'UIS',
-		private: true,
-		lastedited: 'today'
-	},
-	{
-		name: 'Asset #4',
-		status: 'In-progress',
-		department: 'UIS',
-		private: false,
-		lastedited: 'today'
-	},
-	{
-		name: 'Asset #5',
-		status: 'Complete',
-		department: 'UIS',
-		private: true,
-		lastedited: 'today'
-	},
-	{
-		name: 'Asset #6',
-		status: 'In-progress',
-		department: 'UIS',
-		private: true,
-		lastedited: 'today'
-	},
-	{
-		name: 'Asset #7',
-		status: 'In-progress',
-		department: 'UIS',
-		private: false,
-		lastedited: 'today'
-	},
+  {
+    name: 'Asset #1',
+    status: 'In-progress',
+    department: 'UIS',
+    private: true,
+    lastedited: 'today'
+  },
+  {
+    name: 'Asset #2',
+    status: 'In-progress',
+    department: 'UIS',
+    private: true,
+    lastedited: 'today'
+  },
+  {
+    name: 'Asset #3',
+    status: 'Complete',
+    department: 'UIS',
+    private: true,
+    lastedited: 'today'
+  },
+  {
+    name: 'Asset #4',
+    status: 'In-progress',
+    department: 'UIS',
+    private: false,
+    lastedited: 'today'
+  },
+  {
+    name: 'Asset #5',
+    status: 'Complete',
+    department: 'UIS',
+    private: true,
+    lastedited: 'today'
+  },
+  {
+    name: 'Asset #6',
+    status: 'In-progress',
+    department: 'UIS',
+    private: true,
+    lastedited: 'today'
+  },
+  {
+    name: 'Asset #7',
+    status: 'In-progress',
+    department: 'UIS',
+    private: false,
+    lastedited: 'today'
+  },
 ];
 
 const TITLES = {
@@ -71,12 +72,12 @@ const TITLES = {
 
 
 const AssetList = ({ match }) => (
-  <div className="App-main">
+  <Page>
     <AssetListHeader title={TITLES[match.url]} />
     <div className="Asset-table">
       <Table
-      	fixedHeader={true}
-      	selectable={false}
+        fixedHeader={true}
+        selectable={false}
       >
         <TableHeader
           displaySelectAll={false}
@@ -108,7 +109,7 @@ const AssetList = ({ match }) => (
         </TableBody>
       </Table>
     </div>
-  </div>
+  </Page>
 );
 
 export default AssetList;

--- a/src/containers/LoginPage.js
+++ b/src/containers/LoginPage.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import LoginButton from '../components/LoginButton';
+
+/**
+ * A login page requesting that the user log in.
+ */
+export default () => (
+  <div className="App-main">
+    <h1>Welcome to the IAR</h1>
+    <p>
+      The information asset register is a way to record information about the University of
+      Cambridge's information assets.
+    </p>
+    <LoginButton />
+  </div>
+);

--- a/src/containers/LoginPage.test.js
+++ b/src/containers/LoginPage.test.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { render } from '../testutils';
+import LoginPage from './LoginPage';
+
+test('can render LoginPage component', () => {
+  const testInstance = render(<LoginPage />);
+});

--- a/src/containers/Page.js
+++ b/src/containers/Page.js
@@ -1,0 +1,14 @@
+/**
+ * Top-level page for IAR containing sidebar and content.
+ */
+import React from 'react';
+import Sidebar from '../components/Sidebar';
+
+export default ({ children }) => (
+  <div>
+    <Sidebar />
+    <div className="App-main">
+      { children }
+    </div>
+  </div>
+);

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@ import ReactDOM from 'react-dom';
 import './style/index.css';
 import App from './containers/App';
 import registerServiceWorker from './registerServiceWorker';
+import configureStore from './redux/store';
 
-ReactDOM.render(<App />, document.getElementById('root'));
-registerServiceWorker();
+configureStore().then(({store}) => {
+  ReactDOM.render(<App store={store}/>, document.getElementById('root'));
+  registerServiceWorker();
+});

--- a/src/redux/actions/auth.js
+++ b/src/redux/actions/auth.js
@@ -13,7 +13,7 @@ import { login as implicitLogin, logout as implicitLogout } from 'redux-implicit
 const config = {
   url: "https://experimental-oauth2.gcloud.automation.uis.cam.ac.uk/oauth2/auth",
   client: "iar-frontend-local",
-  redirect: window.location.origin + '/',  // HACK: get the base URL of the website
+  redirect: window.location.origin + '/oauth2-callback',  // HACK: get the base URL of the website
   scope: "assetregister",
   width: 500, // Width (in pixels) of login popup window. Optional, default: 400
   height: 400 // Height (in pixels) of login popup window. Optional, default: 400

--- a/src/redux/actions/auth.js
+++ b/src/redux/actions/auth.js
@@ -1,0 +1,30 @@
+/**
+ * Redux actions for authenticating and authorising current user.
+ *
+ * These are relatively thin wrappers around redux-implicit-oauth2's actions. They're put here to
+ * decouple the login/logout logic from having to know the mechanism by which login and logout are
+ * achieved.
+ */
+import { login as implicitLogin, logout as implicitLogout } from 'redux-implicit-oauth2';
+
+/**
+ * OAuth2 credentials configuration for the IAR frontend application.
+ */
+const config = {
+  url: "https://experimental-oauth2.gcloud.automation.uis.cam.ac.uk/oauth2/auth",
+  client: "iar-frontend-local",
+  redirect: window.location.origin + '/',  // HACK: get the base URL of the website
+  scope: "assetregister",
+  width: 500, // Width (in pixels) of login popup window. Optional, default: 400
+  height: 400 // Height (in pixels) of login popup window. Optional, default: 400
+};
+
+/**
+ * Initialise login to application.
+ */
+export const login = () => implicitLogin(config);
+
+/**
+ * Log out from the application.
+ */
+export const logout = implicitLogout;

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -1,0 +1,3 @@
+import { login, logout } from './auth';
+
+export { login, logout };

--- a/src/redux/enhancer.js
+++ b/src/redux/enhancer.js
@@ -1,0 +1,10 @@
+import { applyMiddleware } from 'redux';
+import { authMiddleware as auth } from 'redux-implicit-oauth2';
+import logger from 'redux-logger';
+
+/**
+ * Dispatch "enhancer" for redux. In our case it is simply the list of middlewares we apply.
+ */
+const enhancer = applyMiddleware(auth, logger);
+
+export default enhancer;

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -1,0 +1,7 @@
+import { combineReducers } from 'redux';
+import { authReducer as auth } from 'redux-implicit-oauth2';
+
+/**
+ * Combine all reducers used in the application together into one reducer.
+ */
+export default combineReducers({ auth });

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,16 @@
+import { createStore } from 'redux';
+import reducer from './reducers';
+import reduxEnhancer from './enhancer';
+
+/**
+ * Configure the redux store.
+ *
+ * We use a Promise here to allow for asynchronous configuration in the future.
+ *
+ * @return Promise<Store> Promise resolved with the redux store for the
+ * application.
+ */
+export default (initialState = {}) => {
+  const store = createStore(reducer, initialState, reduxEnhancer);
+  return Promise.resolve({store});
+}

--- a/src/redux/store.test.js
+++ b/src/redux/store.test.js
@@ -1,0 +1,8 @@
+import '../test/mock-localstorage';
+import configureStore from './store';
+
+test('creating store succeeds', () => {
+  return configureStore().then(({store}) => {
+    expect(store).toBeDefined();
+  });
+});

--- a/src/test/mock-localstorage.js
+++ b/src/test/mock-localstorage.js
@@ -1,0 +1,10 @@
+/**
+ * Import this module to mock the global window.localStorage object.
+ *
+ * The redux-implicit-oauth2 package examines localStorage when first run to determine if there is
+ * any OAuth2 token defined for the app.
+ */
+import localStorage from 'mock-local-storage';
+
+global.window = global.window || {};
+window.localStorage = global.localStorage;

--- a/src/testutils.js
+++ b/src/testutils.js
@@ -1,16 +1,33 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import TestRenderer from 'react-test-renderer';
-import { MemoryRouter } from 'react-router-dom'
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import { MemoryRouter } from 'react-router-dom';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import localStorage from 'mock-local-storage';
+import configureMockStore from 'redux-mock-store'
+
+import './test/mock-localstorage.js';
+
+export const mockStore = configureMockStore([]);
+
+export const DEFAULT_INITIAL_STATE = {
+  auth: { isLoggedIn: true },
+};
 
 /*
   Helper function to render a component for testing. Wraps component in the necessary scaffolding and returns the
   TestInstance for checking.
  */
-const render = (component) => {
+const render = (component, {initialState = DEFAULT_INITIAL_STATE} = {}) => {
+  // TODO you should be able to use initialEntries/initialIndex - doesn't seem to add match property
   return TestRenderer.create(
-    // TODO you should be able to use initialEntries/initialIndex - doesn't seem to add match property
-    <MemoryRouter><MuiThemeProvider>{ component }</MuiThemeProvider></MemoryRouter>
+    <Provider store={mockStore(initialState)}>
+      <MemoryRouter>
+        <MuiThemeProvider>
+          { component }
+        </MuiThemeProvider>
+      </MemoryRouter>
+    </Provider>
   ).root;
 };
 


### PR DESCRIPTION
Add redux-implicit-oauth2 and configure a basic sign in flow using a
redux store. The OAuth2 flow is pre-configured to make use of our
experimental OAuth2 deployment. It is left as an open question of where
central configuration information should live for the application.

See [0] for an introduction to the basics of Redux and how it is used in
React apps.

In order to render the Sign In page if the user is not logged in, the
existing Route-s are replaced with a LoginRequiredRoute which examines
the current store to determine if the user is logged in. If not, they
display the sign in page.

In order to allow the sign in page to not have a sidebar, the components
are re-jigged a little to be contained within a common "Page" component
which renders the sidebar. The LoginPage component does not use the
"Page" component and hence does not have a sifebar.

Add the react-styleguidist package which provides browsable documentation
for the components. See [1] for information on how to document
components.

The OAuth2 implicit flow implementation examines window.localStorage
when the page is rendered to determine if an auth token is present. This
does not exist by default in our test environment and so it is mocked
for those tests which require it.

[0] https://redux.js.org/docs/basics/
[1] https://react-styleguidist.js.org/docs/documenting.html