### PR TITLE
Add asset list fetching, asset delete and OAuth token

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react-router-dom": "4.2.2",
     "react-scripts": "1.1.0",
     "redux": "^3.7.2",
+    "redux-api-middleware": "^2.2.0",
     "redux-implicit-oauth2": "^1.2.1",
     "redux-logger": "^3.0.6"
   },

--- a/src/components/AssetListItem.js
+++ b/src/components/AssetListItem.js
@@ -18,7 +18,7 @@ const AssetListItem = ({deleteAsset, asset, ...props}) => (
     <TableRowColumn>{asset.private ? <TickIcon/> : ""}</TableRowColumn>
     <TableRowColumn>{asset.updated_at}</TableRowColumn>
     <TableRowColumn>
-    <RaisedButton onClick={() => deleteAsset(asset.url)}>Delete</RaisedButton>
+      <RaisedButton onClick={() => deleteAsset(asset.id)}>Delete</RaisedButton>
     </TableRowColumn>
   </TableRow>
 );

--- a/src/components/AssetListItem.js
+++ b/src/components/AssetListItem.js
@@ -1,15 +1,33 @@
-import React from 'react'
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Link } from 'react-router-dom';
+
+import { connect } from 'react-redux';
+import { deleteAsset } from '../redux/actions';
+
 import {TableRow, TableRowColumn} from 'material-ui/Table';
+import { RaisedButton } from 'material-ui';
 import TickIcon from 'material-ui/svg-icons/action/done';
 
-const AssetListItem = (props) => (
+const AssetListItem = ({deleteAsset, asset, ...props}) => (
   <TableRow hoverable={true}>
-    <TableRowColumn>{props.name}</TableRowColumn>
-    <TableRowColumn>{props.status}</TableRowColumn>
-    <TableRowColumn>{props.department}</TableRowColumn>
-    <TableRowColumn>{props.private ? <TickIcon/> : ""}</TableRowColumn>
-    <TableRowColumn>{props.lastedited}</TableRowColumn>
+    <TableRowColumn><Link to={'/asset/' + asset.id}>{asset.name}</Link></TableRowColumn>
+    <TableRowColumn>{asset.status}</TableRowColumn>
+    <TableRowColumn>{asset.department}</TableRowColumn>
+    <TableRowColumn>{asset.private ? <TickIcon/> : ""}</TableRowColumn>
+    <TableRowColumn>{asset.updated_at}</TableRowColumn>
+    <TableRowColumn>
+    <RaisedButton onClick={() => deleteAsset(asset.url)}>Delete</RaisedButton>
+    </TableRowColumn>
   </TableRow>
 );
 
-export default AssetListItem;
+AssetListItem.propTypes = {
+  asset: PropTypes.object.isRequired,
+  deleteAsset: PropTypes.func.isRequired,
+};
+
+const mapDispatchToProps = { deleteAsset };
+
+export default connect(null, mapDispatchToProps)(AssetListItem);

--- a/src/components/AssetTable.js
+++ b/src/components/AssetTable.js
@@ -1,0 +1,45 @@
+import React from 'react'; // used implicitly by JSX
+import PropTypes from 'prop-types';
+import {
+  Table,
+  TableBody,
+  TableHeader,
+  TableHeaderColumn,
+  TableRow,
+} from 'material-ui/Table';
+
+const AssetTable = ({ children }) => (
+  <div className="Asset-table">
+    <Table
+      fixedHeader={true}
+      selectable={false}
+    >
+      <TableHeader
+        displaySelectAll={false}
+        adjustForCheckbox={false}
+      >
+        <TableRow>
+          <TableHeaderColumn>Name</TableHeaderColumn>
+          <TableHeaderColumn>Status</TableHeaderColumn>
+          <TableHeaderColumn>Department</TableHeaderColumn>
+          <TableHeaderColumn>Private</TableHeaderColumn>
+          <TableHeaderColumn>Last edited</TableHeaderColumn>
+          <TableHeaderColumn>&nbsp;</TableHeaderColumn>
+        </TableRow>
+      </TableHeader>
+      <TableBody
+        showRowHover={true}
+        displayRowCheckbox={false}
+        className="Asset-table-body"
+      >
+      { children }
+      </TableBody>
+    </Table>
+  </div>
+);
+
+AssetTable.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element)
+};
+
+export default AssetTable;

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -25,7 +25,7 @@ class AssetList extends React.Component {
     <Page>
       <AssetListHeader title={TITLES[this.props.match.url]} />
       <AssetTable>{
-        this.props.assets.map( asset => (
+        this.props.assetList.map( asset => (
           <AssetListItem key={asset.url} asset={asset} />
         ))
       }
@@ -35,11 +35,13 @@ class AssetList extends React.Component {
 };
 
 AssetList.propTypes = {
-  assets: PropTypes.arrayOf(PropTypes.object).isRequired,
+  assetList: PropTypes.arrayOf(PropTypes.object).isRequired,
   getAssetList: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = ({ iarApi }) => ({ assets: iarApi.assets });
+const mapStateToProps = ({ iarApi }) => ({
+  assetList: iarApi.assets.results
+});
 
 const mapDispatchToProps = { getAssetList };
 

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -1,69 +1,14 @@
 // eslint-disable-next-line
 import React, {Component} from 'react'; // used implicitly by JSX
-import {
-  Table,
-  TableBody,
-  TableHeader,
-  TableHeaderColumn,
-  TableRow,
-} from 'material-ui/Table';
+import PropTypes from 'prop-types';
 import AssetListItem from '../components/AssetListItem';
-import AssetListHeader from '../components/AssetListHeader'
-import '../style/App.css';
+import AssetListHeader from '../components/AssetListHeader';
+import AssetTable from '../components/AssetTable';
 import Page from '../containers/Page';
+import { connect } from 'react-redux';
+import { getAssetList } from '../redux/actions';
 
-// Mock data until we can fetch data from the api
-const assetData = [
-  {
-    name: 'Asset #1',
-    status: 'In-progress',
-    department: 'UIS',
-    private: true,
-    lastedited: 'today'
-  },
-  {
-    name: 'Asset #2',
-    status: 'In-progress',
-    department: 'UIS',
-    private: true,
-    lastedited: 'today'
-  },
-  {
-    name: 'Asset #3',
-    status: 'Complete',
-    department: 'UIS',
-    private: true,
-    lastedited: 'today'
-  },
-  {
-    name: 'Asset #4',
-    status: 'In-progress',
-    department: 'UIS',
-    private: false,
-    lastedited: 'today'
-  },
-  {
-    name: 'Asset #5',
-    status: 'Complete',
-    department: 'UIS',
-    private: true,
-    lastedited: 'today'
-  },
-  {
-    name: 'Asset #6',
-    status: 'In-progress',
-    department: 'UIS',
-    private: true,
-    lastedited: 'today'
-  },
-  {
-    name: 'Asset #7',
-    status: 'In-progress',
-    department: 'UIS',
-    private: false,
-    lastedited: 'today'
-  },
-];
+import '../style/App.css';
 
 const TITLES = {
   '/assets/dept': 'Assets: My department',
@@ -71,45 +16,31 @@ const TITLES = {
 };
 
 
-const AssetList = ({ match }) => (
-  <Page>
-    <AssetListHeader title={TITLES[match.url]} />
-    <div className="Asset-table">
-      <Table
-        fixedHeader={true}
-        selectable={false}
-      >
-        <TableHeader
-          displaySelectAll={false}
-          adjustForCheckbox={false}
-        >
-          <TableRow>           
-            <TableHeaderColumn>Name</TableHeaderColumn>
-            <TableHeaderColumn>Status</TableHeaderColumn>
-            <TableHeaderColumn>Department</TableHeaderColumn>
-            <TableHeaderColumn>Private</TableHeaderColumn>
-            <TableHeaderColumn>Last edited</TableHeaderColumn>
-          </TableRow>
-        </TableHeader>
-        <TableBody
-          showRowHover={true}
-          displayRowCheckbox={false}
-          className="Asset-table-body"
-        >
-          {assetData.map( (asset, index) => (
-            <AssetListItem
-              key={index}
-              name={asset.name}
-              status={asset.status}
-              department={asset.department}
-              private={asset.private}
-              lastedited={asset.lastedited}
-            />
-          ))}
-        </TableBody>
-      </Table>
-    </div>
-  </Page>
-);
+class AssetList extends React.Component {
+  componentDidMount() {
+    this.props.getAssetList();
+  }
 
-export default AssetList;
+  render() { return (
+    <Page>
+      <AssetListHeader title={TITLES[this.props.match.url]} />
+      <AssetTable>{
+        this.props.assets.map( asset => (
+          <AssetListItem key={asset.url} asset={asset} />
+        ))
+      }
+      </AssetTable>
+    </Page>);
+  }
+};
+
+AssetList.propTypes = {
+  assets: PropTypes.arrayOf(PropTypes.object).isRequired,
+  getAssetList: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ iarApi }) => ({ assets: iarApi.assets });
+
+const mapDispatchToProps = { getAssetList };
+
+export default connect(mapStateToProps, mapDispatchToProps)(AssetList);

--- a/src/containers/AssetList.test.js
+++ b/src/containers/AssetList.test.js
@@ -10,13 +10,13 @@ const mockAssets = [
 ];
 
 test('can render /assets/dept', () => {
-  const testInstance = render(<AssetList assets={mockAssets} match={{url: '/assets/dept'}}/>);
+  const testInstance = render(<AssetList assetList={mockAssets} match={{url: '/assets/dept'}}/>);
 
   expect(testInstance.findByType(AppBar).props.title).toBe('Assets: My department')
 });
 
 test('can render /assets/all', () => {
-  const testInstance = render(<AssetList assets={mockAssets} match={{url: '/assets/all'}}/>);
+  const testInstance = render(<AssetList assetList={mockAssets} match={{url: '/assets/all'}}/>);
 
   expect(testInstance.findByType(AppBar).props.title).toBe('Assets: All')
 });

--- a/src/containers/AssetList.test.js
+++ b/src/containers/AssetList.test.js
@@ -4,14 +4,19 @@ import { AppBar } from 'material-ui';
 import { render } from '../testutils';
 import AssetList from './AssetList';
 
+const mockAssets = [
+  { name: 'foo', id: 'abc' },
+  { name: 'bar', id: 'def' },
+];
+
 test('can render /assets/dept', () => {
-  const testInstance = render(<AssetList match={{url: '/assets/dept'}}/>);
+  const testInstance = render(<AssetList assets={mockAssets} match={{url: '/assets/dept'}}/>);
 
   expect(testInstance.findByType(AppBar).props.title).toBe('Assets: My department')
 });
 
 test('can render /assets/all', () => {
-  const testInstance = render(<AssetList match={{url: '/assets/all'}}/>);
+  const testInstance = render(<AssetList assets={mockAssets} match={{url: '/assets/all'}}/>);
 
   expect(testInstance.findByType(AppBar).props.title).toBe('Assets: All')
 });

--- a/src/redux/actions/assetRegisterApi.js
+++ b/src/redux/actions/assetRegisterApi.js
@@ -2,26 +2,26 @@ import { RSAA } from 'redux-api-middleware';
 
 export const ASSETS_LIST_REQUEST = Symbol('ASSETS_LIST_REQUEST');
 export const ASSETS_LIST_SUCCESS = Symbol('ASSETS_LIST_SUCCESS');
-export const ASSETS_LIST_FAILURE = Symbol('ASSETS_LIST_FAILURE');
 
 export const ASSETS_DELETE_SUCCESS = Symbol('ASSETS_DELETE_SUCCESS');
 export const ASSETS_DELETE_REQUEST = Symbol('ASSETS_DELETE_REQUEST');
-export const ASSETS_DELETE_FAILURE = Symbol('ASSETS_DELETE_FAILURE');
+
+export const ASSETS_API_FAILURE = Symbol('ASSETS_API_FAILURE');
 
 export const getAssetList = () => ({
   [RSAA]: {
     endpoint: 'http://localhost:8080/assets/',
     method: 'GET',
-    types: [ASSETS_LIST_REQUEST, ASSETS_LIST_SUCCESS, ASSETS_LIST_FAILURE]
+    types: [ASSETS_LIST_REQUEST, ASSETS_LIST_SUCCESS, ASSETS_API_FAILURE]
   }
 });
 
-export const deleteAsset = (url) => ({
+export const deleteAsset = (id) => ({
   [RSAA]: {
-    endpoint: url,
+    endpoint: 'http://localhost:8080/assets/' + id + '/',
     method: 'DELETE',
     types: [
-      ASSETS_DELETE_REQUEST, { type: ASSETS_DELETE_SUCCESS, meta: { url } }, ASSETS_DELETE_FAILURE
+      ASSETS_DELETE_REQUEST, { type: ASSETS_DELETE_SUCCESS, meta: { id } }, ASSETS_API_FAILURE
     ]
   }
 });

--- a/src/redux/actions/assetRegisterApi.js
+++ b/src/redux/actions/assetRegisterApi.js
@@ -1,0 +1,27 @@
+import { RSAA } from 'redux-api-middleware';
+
+export const ASSETS_LIST_REQUEST = Symbol('ASSETS_LIST_REQUEST');
+export const ASSETS_LIST_SUCCESS = Symbol('ASSETS_LIST_SUCCESS');
+export const ASSETS_LIST_FAILURE = Symbol('ASSETS_LIST_FAILURE');
+
+export const ASSETS_DELETE_SUCCESS = Symbol('ASSETS_DELETE_SUCCESS');
+export const ASSETS_DELETE_REQUEST = Symbol('ASSETS_DELETE_REQUEST');
+export const ASSETS_DELETE_FAILURE = Symbol('ASSETS_DELETE_FAILURE');
+
+export const getAssetList = () => ({
+  [RSAA]: {
+    endpoint: 'http://localhost:8080/assets/',
+    method: 'GET',
+    types: [ASSETS_LIST_REQUEST, ASSETS_LIST_SUCCESS, ASSETS_LIST_FAILURE]
+  }
+});
+
+export const deleteAsset = (url) => ({
+  [RSAA]: {
+    endpoint: url,
+    method: 'DELETE',
+    types: [
+      ASSETS_DELETE_REQUEST, { type: ASSETS_DELETE_SUCCESS, meta: { url } }, ASSETS_DELETE_FAILURE
+    ]
+  }
+});

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -1,3 +1,4 @@
 import { login, logout } from './auth';
+import { getAssetList, deleteAsset } from './assetRegisterApi';
 
-export { login, logout };
+export { login, logout, getAssetList, deleteAsset };

--- a/src/redux/enhancer.js
+++ b/src/redux/enhancer.js
@@ -1,10 +1,14 @@
 import { applyMiddleware } from 'redux';
 import { authMiddleware as auth } from 'redux-implicit-oauth2';
 import logger from 'redux-logger';
+import { apiMiddleware as api } from 'redux-api-middleware';
+
+export const middlewares = [auth, api];
 
 /**
- * Dispatch "enhancer" for redux. In our case it is simply the list of middlewares we apply.
+ * Dispatch "enhancer" for redux. In our case it is simply the list of middlewares passed to
+ * applyMiddleware.
  */
-const enhancer = applyMiddleware(auth, logger);
+const enhancer = applyMiddleware(...middlewares, logger);
 
 export default enhancer;

--- a/src/redux/enhancer.js
+++ b/src/redux/enhancer.js
@@ -2,8 +2,9 @@ import { applyMiddleware } from 'redux';
 import { authMiddleware as auth } from 'redux-implicit-oauth2';
 import logger from 'redux-logger';
 import { apiMiddleware as api } from 'redux-api-middleware';
+import apiAuth from './middlewares/apiAuth';
 
-export const middlewares = [auth, api];
+export const middlewares = [auth, apiAuth, api];
 
 /**
  * Dispatch "enhancer" for redux. In our case it is simply the list of middlewares passed to

--- a/src/redux/middlewares/apiAuth.js
+++ b/src/redux/middlewares/apiAuth.js
@@ -1,0 +1,34 @@
+/**
+ * Middleware to add authorisation headers to redux-api-middleware RSAA actions.
+ *
+ * The result of the RSSA action is observed. If it has the following form:
+ *
+ *    { error: true, payload: { status: 401 } }
+ *
+ * then the user is signed out. When we have plumbing for this, it would be nicer to sign the user
+ * in silently.
+ */
+import { isRSAA, RSAA } from 'redux-api-middleware';
+import { logout } from '../actions';
+
+export default ({ getState, dispatch }) => next => action => {
+  // pass non-RSAA actions to next middleware
+  if(!isRSAA(action)) { return next(action); }
+
+  // update action with authorisation headers
+  const { auth } = getState();
+  const authHeaders = (!auth || !auth.isLoggedIn) ?
+    { } : { 'Authorization': 'Bearer ' + auth.token };
+  const updatedAction = {
+    ...action,
+    [RSAA]: {...action[[RSAA]], headers: authHeaders }
+  };
+
+  // pass action to next middleware
+  return next(updatedAction).then(({ error, payload }) => {
+    if(error && payload && (payload.status === 401)) {
+      // TODO: have a less abrupt UI for this!
+      dispatch(logout());
+    }
+  });
+};

--- a/src/redux/reducers/assetRegisterApi.js
+++ b/src/redux/reducers/assetRegisterApi.js
@@ -1,0 +1,16 @@
+import { ASSETS_LIST_SUCCESS, ASSETS_DELETE_SUCCESS } from '../actions/assetRegisterApi';
+
+const initialState = {
+  assets: []
+}
+
+export default (state = initialState, action) => {
+  switch(action.type) {
+    case ASSETS_LIST_SUCCESS:
+      return {...state, assets: action.payload.results};
+    case ASSETS_DELETE_SUCCESS:
+      return {...state, assets: state.assets.filter(asset => (asset.url !== action.meta.url))};
+    default:
+      return state;
+  }
+};

--- a/src/redux/reducers/assetRegisterApi.js
+++ b/src/redux/reducers/assetRegisterApi.js
@@ -1,15 +1,40 @@
 import { ASSETS_LIST_SUCCESS, ASSETS_DELETE_SUCCESS } from '../actions/assetRegisterApi';
 
-const initialState = {
-  assets: []
+/**
+ * State managed by the asset API reducers.
+ *
+ * This state mirrors the REST API endpoints.
+ */
+export const initialState = {
+  // Current list of asset summaries fetched from .../assets/ endpoint.
+  assets: {
+    // If not-null, this URL should be used to fetch results to add to the end of the current asset
+    // list in order to extend it.
+    next: null,
+
+    // If not-null, this URL should be used to fetch results to add to the beginning of the current
+    // asset list in order to extend it.
+    previous: null,
+
+    // List of asset summaries.
+    results: [ ],
+  },
 }
 
 export default (state = initialState, action) => {
   switch(action.type) {
-    case ASSETS_LIST_SUCCESS:
-      return {...state, assets: action.payload.results};
-    case ASSETS_DELETE_SUCCESS:
-      return {...state, assets: state.assets.filter(asset => (asset.url !== action.meta.url))};
+    case ASSETS_LIST_SUCCESS: {
+      const { next, previous, results } = action.payload;
+      return { ...state, assets: { ...state.assets, next, previous, results } };
+    }
+    case ASSETS_DELETE_SUCCESS: {
+      return {
+        ...state, assets: {
+          ...state.assets,
+          results: state.assets.results.filter(asset => (asset.id !== action.meta.id))
+        }
+      };
+    }
     default:
       return state;
   }

--- a/src/redux/reducers/assetRegisterApi.test.js
+++ b/src/redux/reducers/assetRegisterApi.test.js
@@ -1,0 +1,20 @@
+import reducer, { initialState } from './assetRegisterApi';
+import { ASSETS_LIST_SUCCESS, ASSETS_DELETE_SUCCESS } from '../actions/assetRegisterApi';
+
+test('asset list response updates state', () => {
+  const action = { type: ASSETS_LIST_SUCCESS, payload: {
+    next: 'xxx', previous: 'yyy', results: ['a', 'b'] } };
+  const nextState = reducer(initialState, action);
+  expect(nextState.assets.next).toBe('xxx');
+  expect(nextState.assets.previous).toBe('yyy');
+  expect(nextState.assets.results).toEqual(['a', 'b']);
+});
+
+test('asset delete response deletes asset', () => {
+  const previousState = { ...initialState,
+    assets: { ...initialState.assets, results: [ {id: 'x'}, {id: 'y'}, {id: 'z'} ] },
+  };
+  const action = { type: ASSETS_DELETE_SUCCESS, meta: { id: 'y' } };
+  const nextState = reducer(previousState, action);
+  expect(nextState.assets.results).toEqual([{id: 'x'}, {id: 'z'}]);
+});

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -1,7 +1,8 @@
 import { combineReducers } from 'redux';
 import { authReducer as auth } from 'redux-implicit-oauth2';
+import iarApi from './assetRegisterApi';
 
 /**
  * Combine all reducers used in the application together into one reducer.
  */
-export default combineReducers({ auth });
+export default combineReducers({ auth, iarApi });

--- a/src/testutils.js
+++ b/src/testutils.js
@@ -6,6 +6,7 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import localStorage from 'mock-local-storage';
 import configureMockStore from 'redux-mock-store';
 import { middlewares } from './redux/enhancer';
+import { initialState as iarApiInitialState } from './redux/reducers/assetRegisterApi';
 
 import './test/mock-localstorage.js';
 
@@ -13,7 +14,7 @@ export const mockStore = configureMockStore(middlewares);
 
 export const DEFAULT_INITIAL_STATE = {
   auth: { isLoggedIn: true },
-  iarApi: { assets: [] },
+  iarApi: iarApiInitialState,
 };
 
 /*

--- a/src/testutils.js
+++ b/src/testutils.js
@@ -4,14 +4,16 @@ import TestRenderer from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import localStorage from 'mock-local-storage';
-import configureMockStore from 'redux-mock-store'
+import configureMockStore from 'redux-mock-store';
+import { middlewares } from './redux/enhancer';
 
 import './test/mock-localstorage.js';
 
-export const mockStore = configureMockStore([]);
+export const mockStore = configureMockStore(middlewares);
 
 export const DEFAULT_INITIAL_STATE = {
   auth: { isLoggedIn: true },
+  iarApi: { assets: [] },
 };
 
 /*


### PR DESCRIPTION
Based on @joeadams04's work, this PR wires up the backend API to the AssetList.

The PR looks larger than it is because 4f75326 takes the opportunity to refactor the rather large AssetList component into separate components and removes the mocked data. New functionality is confined to the ``src/redux`` directory.

9a51c76 adds authorisation to the API. I've implemented this as a custom middleware for the moment since we have yet to fully settle on the token timeout behaviour. This will depend slightly on what our final OAuth2 deployment looks like.

**NOTE:** This PR depends on https://github.com/uisautomation/iar-backend/pull/15 and https://github.com/uisautomation/iar-backend/pull/16 for correct functioning.

Closes #25. Closes #12.