### PR TITLE
restore scroll position to top of screen on navigate

### DIFF
--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -1,0 +1,19 @@
+// Taken from
+// https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md
+
+import { Component } from 'react';
+import { withRouter } from 'react-router-dom';
+
+class ScrollToTop extends Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+};
+
+export default withRouter(ScrollToTop);

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -6,6 +6,7 @@ import { Snackbar } from 'material-ui';
 import RoutedAssetList from './RoutedAssetList'
 import RoutedAssetForm from './RoutedAssetForm'
 import RoutedStatic from './RoutedStatic'
+import ScrollToTop from '../components/ScrollToTop';
 import PropTypes from 'prop-types';
 import '../style/App.css'
 
@@ -60,6 +61,7 @@ class App extends Component {
               />
             </div>
           </MuiThemeProvider>
+          <ScrollToTop />
         </Router>
       </Provider>
     );


### PR DESCRIPTION
Since we have multiple long scrolling pages in the app, implement the
ScrollToTop component as noted here.

A different fix is to make each of our pages scroll *within* the
component via overflow: scroll or the like.

[1] https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md