### PR TITLE
add sorting to the asset list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,24 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/jss": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.3.0.tgz",
+      "integrity": "sha512-n7MUYCO/Wt4d6Yj0ZewXSSkqBcrdLFgpQ4mUBRXBWDmLfXtgT3tJ26GVPr8HiyRLLze6iQfaBJTlvjRTjgZpRg=="
+    },
+    "@types/react": {
+      "version": "16.0.36",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.36.tgz",
+      "integrity": "sha512-q33EVfy4i+fwhM31PL6/c6Job/DyjOiExHuR163bJK3rEMRf2ENkBrN4thQH5cwA+TiiN1vWDZU6D5H1AvQTlA=="
+    },
+    "@types/react-transition-group": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.6.tgz",
+      "integrity": "sha512-mVhRv+d0MIoLWl6hEFA7Nnd/obW2RQpZViTAKhM37mltuTDWCdoj8xAZv94ntB8wgAc6DDiDCXxFXPgClGnsfQ==",
+      "requires": {
+        "@types/react": "16.0.36"
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -1319,11 +1337,6 @@
         "hoek": "4.2.0"
       }
     },
-    "bowser": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.1.tgz",
-      "integrity": "sha512-UXti1JB6oK8hO983AImunnV6j/fqAEeDlPXh99zhsP5g32oLbxJJ6qcOaUesR+tqqhnUVQHlRJyD0dfiV0Hxaw=="
-    },
     "boxen": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
@@ -1383,6 +1396,11 @@
         "preserve": "0.2.0",
         "repeat-element": "1.1.2"
       }
+    },
+    "brcast": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
+      "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
     },
     "brorand": {
       "version": "1.1.0",
@@ -1907,8 +1925,7 @@
     "classnames": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0=",
-      "dev": true
+      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
     },
     "clean-css": {
       "version": "4.1.9",
@@ -2444,14 +2461,6 @@
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA="
     },
-    "css-in-js-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",
-      "integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
-      "requires": {
-        "hyphenate-style-name": "1.0.2"
-      }
-    },
     "css-initials": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/css-initials/-/css-initials-0.2.0.tgz",
@@ -2541,6 +2550,14 @@
             "regjsparser": "0.1.5"
           }
         }
+      }
+    },
+    "css-vendor": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
+      "integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
+      "requires": {
+        "is-in-browser": "1.1.3"
       }
     },
     "css-what": {
@@ -2769,6 +2786,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "deepmerge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.0.1.tgz",
+      "integrity": "sha512-VIPwiMJqJ13ZQfaCsIFnp5Me9tnjURiaIFxfz7EH0Ci0dTSQpZtSLrqOicXqEd/z2r+z+Klk9GzmnRsgpgbOsQ=="
+    },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -2985,8 +3007,7 @@
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domain-browser": {
       "version": "1.1.7",
@@ -5008,7 +5029,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true,
       "requires": {
         "min-document": "2.19.0",
         "process": "0.5.2"
@@ -5017,8 +5037,7 @@
         "process": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-          "dev": true
+          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
         }
       }
     },
@@ -5556,11 +5575,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
-    "hyphenate-style-name": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
-    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -5645,15 +5659,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "inline-style-prefixer": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz",
-      "integrity": "sha1-hVG45bTVcyROZqNLBPfTIHaitTQ=",
-      "requires": {
-        "bowser": "1.9.1",
-        "css-in-js-utils": "2.0.0"
-      }
     },
     "inquirer": {
       "version": "3.3.0",
@@ -5916,6 +5921,11 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
+    "is-function": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+    },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -5933,8 +5943,7 @@
     "is-in-browser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
-      "dev": true
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-npm": {
       "version": "1.0.0",
@@ -6004,7 +6013,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "3.0.1"
       },
@@ -6012,8 +6020,7 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-          "dev": true
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         }
       }
     },
@@ -6657,7 +6664,6 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/jss/-/jss-9.6.0.tgz",
       "integrity": "sha512-fnj0UV//VdgxwH0h9pOZljAwFlJMZTAeaDD6u9G0VFMSDwTgdRYxV7+/RZohZYMEVITkgXedHiQHW5ETRVAXkA==",
-      "dev": true,
       "requires": {
         "is-in-browser": "1.1.3",
         "symbol-observable": "1.1.0",
@@ -6667,14 +6673,12 @@
     "jss-camel-case": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.0.0.tgz",
-      "integrity": "sha512-XAYa7JpGkLdlLgEfuzSQSVONRzSVvv4Tvyv5H8hLmJuHeFHTWwVrJrW1Cg/buED3izXKwTU2KBGpeXjIR5Eaew==",
-      "dev": true
+      "integrity": "sha512-XAYa7JpGkLdlLgEfuzSQSVONRzSVvv4Tvyv5H8hLmJuHeFHTWwVrJrW1Cg/buED3izXKwTU2KBGpeXjIR5Eaew=="
     },
     "jss-compose": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-5.0.0.tgz",
       "integrity": "sha512-YofRYuiA0+VbeOw0VjgkyO380sA4+TWDrW52nSluD9n+1FWOlDzNbgpZ/Sb3Y46+DcAbOS21W5jo6SAqUEiuwA==",
-      "dev": true,
       "requires": {
         "warning": "3.0.0"
       }
@@ -6682,14 +6686,25 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
-      "dev": true
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
+    },
+    "jss-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-5.1.0.tgz",
+      "integrity": "sha512-WTxmNipgj0V8kr8gc8Gc6Et7uQZH60H7FFNG9zZHjR6TPJoj7TDK+/EBxwRHtCRQD4B8RTwoa7MyEKD4ReKfXw=="
+    },
+    "jss-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-6.2.0.tgz",
+      "integrity": "sha512-YszrmcB6o9HOsKPszK7NeDBNNjVyiW864jfoiHoMlgMIg2qlxKw70axZHqgczXHDcoyi/0/ikP1XaHDPRvYtEA==",
+      "requires": {
+        "warning": "3.0.0"
+      }
     },
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
-      "dev": true
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
     },
     "jss-isolate": {
       "version": "5.1.0",
@@ -6704,9 +6719,46 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
       "integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
-      "dev": true,
       "requires": {
         "warning": "3.0.0"
+      }
+    },
+    "jss-preset-default": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-4.2.0.tgz",
+      "integrity": "sha512-vifeZEik8bvBZZB1TnpLZ3bm0WwBlDQ+6bmXExyEkCK50IoLiTt3j+yoWWBjbjpRQ2UQbD0FthtVGUM2alc+ow==",
+      "requires": {
+        "jss-camel-case": "6.0.0",
+        "jss-compose": "5.0.0",
+        "jss-default-unit": "8.0.2",
+        "jss-expand": "5.1.0",
+        "jss-extend": "6.2.0",
+        "jss-global": "3.0.0",
+        "jss-nested": "6.0.1",
+        "jss-props-sort": "6.0.0",
+        "jss-template": "1.0.1",
+        "jss-vendor-prefixer": "7.0.0"
+      }
+    },
+    "jss-props-sort": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
+    },
+    "jss-template": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jss-template/-/jss-template-1.0.1.tgz",
+      "integrity": "sha512-m5BqEWha17fmIVXm1z8xbJhY6GFJxNB9H68GVnCWPyGYfxiAgY9WTQyvDAVj+pYRgrXSOfN5V1T4+SzN1sJTeg==",
+      "requires": {
+        "warning": "3.0.0"
+      }
+    },
+    "jss-vendor-prefixer": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
+      "integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
+      "requires": {
+        "css-vendor": "0.3.8"
       }
     },
     "jsx-ast-utils": {
@@ -6901,18 +6953,12 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-    },
-    "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
     },
     "lodash.template": {
       "version": "4.4.0",
@@ -6930,11 +6976,6 @@
       "requires": {
         "lodash._reinterpolate": "3.0.0"
       }
-    },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -7104,21 +7145,45 @@
       }
     },
     "material-ui": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-0.20.0.tgz",
-      "integrity": "sha512-wkHkeU1SaGfCrtwIzBOl5vynNNNzVGW27ql0Ue5HZLB4WyRQ3YohJBdKa5lBrH5JD/Cgae7IzrP7cVWDyKpeLQ==",
+      "version": "1.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.32.tgz",
+      "integrity": "sha512-f8srx1qmAmD5lAuKPxVg5lWUkyIJAwsK31yU3jk2v5gMFVIruwf3qYIuZMb5tklVu1qt7qoR7SrH1Zo7oiFxjA==",
       "requires": {
+        "@types/jss": "9.3.0",
+        "@types/react-transition-group": "2.0.6",
         "babel-runtime": "6.26.0",
-        "inline-style-prefixer": "3.0.8",
+        "brcast": "3.0.1",
+        "classnames": "2.2.5",
+        "deepmerge": "2.0.1",
+        "dom-helpers": "3.3.1",
+        "hoist-non-react-statics": "2.3.1",
+        "jss": "9.6.0",
+        "jss-camel-case": "6.0.0",
+        "jss-default-unit": "8.0.2",
+        "jss-global": "3.0.0",
+        "jss-nested": "6.0.1",
+        "jss-props-sort": "6.0.0",
+        "jss-vendor-prefixer": "7.0.0",
         "keycode": "2.1.9",
-        "lodash.merge": "4.6.0",
-        "lodash.throttle": "4.1.1",
+        "lodash": "4.17.4",
+        "normalize-scroll-left": "0.1.2",
         "prop-types": "15.6.0",
         "react-event-listener": "0.5.3",
-        "react-transition-group": "1.2.1",
+        "react-jss": "8.2.1",
+        "react-popper": "0.7.5",
+        "react-scrollbar-size": "2.1.0",
+        "react-transition-group": "2.2.1",
         "recompose": "0.26.0",
-        "simple-assign": "0.1.0",
+        "scroll": "2.0.1",
         "warning": "3.0.0"
+      }
+    },
+    "material-ui-icons": {
+      "version": "1.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/material-ui-icons/-/material-ui-icons-1.0.0-beta.17.tgz",
+      "integrity": "sha1-XxmvVKLZnu7zR6VUFKaFPhyFDcM=",
+      "requires": {
+        "recompose": "0.26.0"
       }
     },
     "math-expression-evaluator": {
@@ -7273,7 +7338,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
       "requires": {
         "dom-walk": "0.1.1"
       }
@@ -7577,6 +7641,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+    },
+    "normalize-scroll-left": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
+      "integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg=="
     },
     "normalize-url": {
       "version": "1.9.1",
@@ -8138,6 +8207,11 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+    },
+    "popper.js": {
+      "version": "1.12.9",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
+      "integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
     },
     "portfinder": {
       "version": "1.0.13",
@@ -9522,6 +9596,14 @@
         "performance-now": "2.1.0"
       }
     },
+    "rafl": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rafl/-/rafl-1.2.2.tgz",
+      "integrity": "sha1-/pMPdYIRAg1H44gV9Rlqi+QVB0A=",
+      "requires": {
+        "global": "4.3.2"
+      }
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -9774,6 +9856,27 @@
         "react-icon-base": "2.1.0"
       }
     },
+    "react-jss": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-8.2.1.tgz",
+      "integrity": "sha512-H1fm32xG8pi4LMHkXjqpLyFOvSDsravd0HI6Dtlb/iyma1tfi7qqqSH2bf0kKyTAJV5hvYL0ls0qvRJWKfDPcA==",
+      "requires": {
+        "hoist-non-react-statics": "2.3.1",
+        "jss": "9.6.0",
+        "jss-preset-default": "4.2.0",
+        "prop-types": "15.6.0",
+        "theming": "1.3.0"
+      }
+    },
+    "react-popper": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
+      "integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
+      "requires": {
+        "popper.js": "1.12.9",
+        "prop-types": "15.6.0"
+      }
+    },
     "react-redux": {
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
@@ -9867,6 +9970,17 @@
             "asap": "2.0.6"
           }
         }
+      }
+    },
+    "react-scrollbar-size": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-scrollbar-size/-/react-scrollbar-size-2.1.0.tgz",
+      "integrity": "sha512-9dDUJvk7S48r0TRKjlKJ9e/LkLLYgc9LdQR6W21I8ZqtSrEsedPOoMji4nU3DHy7fx2l8YMScJS/N7qiloYzXQ==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "prop-types": "15.6.0",
+        "react-event-listener": "0.5.3",
+        "stifle": "1.0.4"
       }
     },
     "react-styleguidist": {
@@ -10569,11 +10683,12 @@
       }
     },
     "react-transition-group": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
+      "integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
       "requires": {
         "chain-function": "1.0.0",
+        "classnames": "2.2.5",
         "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.0",
@@ -10761,6 +10876,16 @@
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.1.0"
+      }
+    },
+    "redux-api-middleware": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/redux-api-middleware/-/redux-api-middleware-2.2.0.tgz",
+      "integrity": "sha512-NnRrV6IXJ6suCUCQP6y+INa8CTOHWak5aign5BBvhyuIkDJzmmpNsq4EOB4SFlbHWhwE+Z9tmHYD4P/sN+qbLA==",
+      "requires": {
+        "babel-plugin-transform-runtime": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "lodash.isplainobject": "4.0.6"
       }
     },
     "redux-implicit-oauth2": {
@@ -11219,6 +11344,14 @@
         "ajv": "5.5.2"
       }
     },
+    "scroll": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/scroll/-/scroll-2.0.1.tgz",
+      "integrity": "sha1-tMfSfovPOuiligQvJyaK4/VfnM0=",
+      "requires": {
+        "rafl": "1.2.2"
+      }
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -11397,11 +11530,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "simple-assign": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/simple-assign/-/simple-assign-0.1.0.tgz",
-      "integrity": "sha1-F/0wZqXz13OPUDIbsPFMooHMS6o="
     },
     "slash": {
       "version": "1.0.0",
@@ -11835,6 +11963,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
     },
+    "stifle": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stifle/-/stifle-1.0.4.tgz",
+      "integrity": "sha1-izvN9SQZsKnHnjWtrc5QEjwdjpk="
+    },
     "stream-browserify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
@@ -12110,6 +12243,17 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "theming": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
+      "integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
+      "requires": {
+        "brcast": "3.0.1",
+        "is-function": "1.0.1",
+        "is-plain-object": "2.0.4",
+        "prop-types": "15.6.0"
+      }
     },
     "throat": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "material-ui": "^0.20.0",
+    "material-ui": "^1.0.0-beta.32",
+    "material-ui-icons": "^1.0.0-beta.17",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/src/components/AssetFormHeader.js
+++ b/src/components/AssetFormHeader.js
@@ -1,22 +1,38 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-import { AppBar, RaisedButton } from 'material-ui';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { withStyles } from 'material-ui/styles';
+import AppBar from 'material-ui/AppBar';
+import Toolbar from 'material-ui/Toolbar';
+import Typography from 'material-ui/Typography';
+import Button from 'material-ui/Button';
+
+const styles = {
+  flex: { flex: 1 },
+};
 
 /*
-  Renders the app bar of the form for the creation/editing of an Asset.
+  Renders the app bar of the list view of Assets.
   */
-const AssetFormHeader = (props) => (
-  <div className="App-header">
-    <AppBar title={ props.title } iconElementRight={
-      <span>
-        <Link className='App-raised-button-link' to="/">
-          <RaisedButton primary={true} label="Cancel"/>
-        </Link>
-        &nbsp;
-        <RaisedButton label="Save" onClick={props.onClick}/>
-      </span>
-    } />
-  </div>
+const AssetFormHeader = ({ title, onClick, classes }) => (
+  <AppBar position="static">
+    <Toolbar>
+      <Typography variant="title" color="inherit" className={classes.flex}>
+        { title }
+      </Typography>
+      <Link className='App-raised-button-link' to="/">
+        <Button variant="raised" color='primary'>Cancel</Button>
+      </Link>
+      &nbsp;
+      <Button variant="raised" onClick={onClick}>Save</Button>
+    </Toolbar>
+  </AppBar>
 );
 
-export default AssetFormHeader;
+AssetFormHeader.propTypes = {
+  classes: PropTypes.object.isRequired,
+  title: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
+};
+
+export default withStyles(styles)(AssetFormHeader);

--- a/src/components/AssetListHeader.js
+++ b/src/components/AssetListHeader.js
@@ -1,18 +1,35 @@
 import React from 'react';
-import { Link } from 'react-router-dom'
-import { AppBar, RaisedButton } from 'material-ui';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { withStyles } from 'material-ui/styles';
+import AppBar from 'material-ui/AppBar';
+import Toolbar from 'material-ui/Toolbar';
+import Typography from 'material-ui/Typography';
+import Button from 'material-ui/Button';
+
+const styles = {
+  flex: { flex: 1 },
+};
 
 /*
   Renders the app bar of the list view of Assets.
   */
-const AssetListHeader = ({ title }) => (
-  <div className="App-header">
-    <AppBar title={ title } iconElementRight={
+const AssetListHeader = ({ title, classes }) => (
+  <AppBar position="static">
+    <Toolbar>
+      <Typography variant="title" color="inherit" className={classes.flex}>
+        { title }
+      </Typography>
       <Link className='App-raised-button-link' to="/asset/create">
-        <RaisedButton label="Create Asset"/>
+        <Button variant='raised'>Create Asset</Button>
       </Link>
-    } />
-  </div>
+    </Toolbar>
+  </AppBar>
 );
 
-export default AssetListHeader;
+AssetListHeader.propTypes = {
+  classes: PropTypes.object.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+export default withStyles(styles)(AssetListHeader);

--- a/src/components/AssetListItem.js
+++ b/src/components/AssetListItem.js
@@ -6,31 +6,22 @@ import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { confirmDelete } from '../redux/actions/deleteConfirmation';
 
-import {TableRow, TableRowColumn} from 'material-ui/Table';
-import TickIcon from 'material-ui/svg-icons/action/done';
-import IconMenu from 'material-ui/IconMenu';
-import MenuItem from 'material-ui/MenuItem';
-import IconButton from 'material-ui/IconButton';
-import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
+import {TableRow, TableCell} from 'material-ui/Table';
+import TickIcon from 'material-ui-icons/Done';
+import Button from 'material-ui/Button';
 
 const AssetListItem = ({confirmDelete, asset}) => (
-  <TableRow hoverable={true}>
-    <TableRowColumn><Link to={'/asset/' + asset.id}>
+  <TableRow>
+    <TableCell><Link to={'/asset/' + asset.id}>
       {asset.name ? asset.name : asset.id}
-    </Link></TableRowColumn>
-    <TableRowColumn>{asset.is_complete ? 'Complete' : 'In Progress'}</TableRowColumn>
-    <TableRowColumn>{asset.department}</TableRowColumn>
-    <TableRowColumn>{asset.private ? <TickIcon/> : ""}</TableRowColumn>
-    <TableRowColumn>{asset.updated_at}</TableRowColumn>
-    <TableRowColumn>
-      <IconMenu
-        iconButtonElement={<IconButton><MoreVertIcon /></IconButton>}
-        anchorOrigin={{horizontal: 'right', vertical: 'top'}}
-        targetOrigin={{horizontal: 'right', vertical: 'top'}}
-      >
-        <MenuItem primaryText="Delete" onClick={() => confirmDelete(asset.url)} />
-      </IconMenu>
-    </TableRowColumn>
+    </Link></TableCell>
+    <TableCell>{asset.is_complete ? 'Complete' : 'In Progress'}</TableCell>
+    <TableCell>{asset.department}</TableCell>
+    <TableCell>{asset.private ? <TickIcon/> : ""}</TableCell>
+    <TableCell>{asset.updated_at}</TableCell>
+    <TableCell>
+      <Button onClick={() => confirmDelete(asset.url)}>Delete</Button>
+    </TableCell>
   </TableRow>
 );
 

--- a/src/components/AssetListItem.test.js
+++ b/src/components/AssetListItem.test.js
@@ -1,18 +1,21 @@
 import React from 'react';
 import { render } from '../testutils';
+import Table, { TableBody } from 'material-ui/Table';
 import { UnconnectedAssetListItem as AssetListItem } from './AssetListItem';
 import { Link } from 'react-router-dom';
 
+const Container = ({ children }) => (<Table><TableBody>{ children }</TableBody></Table>);
+
 test('Asset list should show asset name if present', () => {
-  const component = <AssetListItem
-    asset={{name:'foo', id:'bar'}} assetUrl='xxx' confirmDelete={() => null} />
+  const component = <Container><AssetListItem
+    asset={{name:'foo', id:'bar'}} assetUrl='xxx' confirmDelete={() => null} /></Container>
   const testInstance = render(component, {url:'/'});
   expect(testInstance.findByProps({ href: '/asset/bar' }).children).toContain('foo');
 });
 
 test('Asset list should show asset id if name not present', () => {
-  const component = <AssetListItem
-    asset={{id:'bar'}} assetUrl='xxx' confirmDelete={() => null} />
+  const component = <Container><AssetListItem
+    asset={{id:'bar'}} assetUrl='xxx' confirmDelete={() => null} /></Container>
   const testInstance = render(component, {url:'/'});
   expect(testInstance.findByProps({ href: '/asset/bar' }).children).toContain('bar');
 });

--- a/src/components/AssetTable.js
+++ b/src/components/AssetTable.js
@@ -1,60 +1,18 @@
 import React from 'react'; // used implicitly by JSX
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-
-import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
-import AssetListItem from './AssetListItem';
+import Table from 'material-ui/Table';
+import AssetTableHeader from './AssetTableHeader';
+import AssetTableBody from './AssetTableBody';
 
 /**
  * A table of assets.
  */
-export const AssetTable = ({ assetSummaries, isLoadingAssets = false }) => (
+export const AssetTable = () => (
   <div className="Asset-table">
     <Table>
-      <TableHead>
-        <TableRow>
-          <TableCell>Name</TableCell>
-          <TableCell>Status</TableCell>
-          <TableCell>Department</TableCell>
-          <TableCell>Private</TableCell>
-          <TableCell>Last edited</TableCell>
-          <TableCell>&nbsp;</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody className="Asset-table-body">
-        {
-          // Display a "no assets" row if there is no loading happening and there are no assets.
-          ((assetSummaries.length === 0) && !isLoadingAssets) ? <ZeroAssetsRow /> : null
-        }
-        { assetSummaries.map(({ url }) => <AssetListItem key={url} assetUrl={url} />) }
-      </TableBody>
+      <AssetTableHeader />
+      <AssetTableBody />
     </Table>
   </div>
 );
 
-AssetTable.propTypes = {
-  assetSummaries: PropTypes.arrayOf(PropTypes.object).isRequired,
-  isLoadingAssets: PropTypes.bool,
-};
-
-/**
- * Table row which is displayed when there are no assets in the current list.
- */
-export const ZeroAssetsRow = () => (
-  <TableRow>
-    <TableCell colSpan={6} style={{textAlign: 'center'}}>
-      There are no assets to display
-    </TableCell>
-  </TableRow>
-);
-
-// Export unconnected version of component to ease testing
-export const UnconnectedAssetTable = AssetTable;
-
-const mapStateToProps = ({
-  assets: { summaries: assetSummaries, isLoading: isLoadingAssets }
-}) => ({
-  assetSummaries, isLoadingAssets
-});
-
-export default connect(mapStateToProps)(AssetTable);
+export default AssetTable;

--- a/src/components/AssetTable.js
+++ b/src/components/AssetTable.js
@@ -2,14 +2,7 @@ import React from 'react'; // used implicitly by JSX
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import {
-  Table,
-  TableBody,
-  TableHeader,
-  TableHeaderColumn,
-  TableRow,
-  TableRowColumn,
-} from 'material-ui/Table';
+import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
 import AssetListItem from './AssetListItem';
 
 /**
@@ -17,28 +10,18 @@ import AssetListItem from './AssetListItem';
  */
 export const AssetTable = ({ assetSummaries, isLoadingAssets = false }) => (
   <div className="Asset-table">
-    <Table
-      fixedHeader={true}
-      selectable={false}
-    >
-      <TableHeader
-        displaySelectAll={false}
-        adjustForCheckbox={false}
-      >
+    <Table>
+      <TableHead>
         <TableRow>
-          <TableHeaderColumn>Name</TableHeaderColumn>
-          <TableHeaderColumn>Status</TableHeaderColumn>
-          <TableHeaderColumn>Department</TableHeaderColumn>
-          <TableHeaderColumn>Private</TableHeaderColumn>
-          <TableHeaderColumn>Last edited</TableHeaderColumn>
-          <TableHeaderColumn>&nbsp;</TableHeaderColumn>
+          <TableCell>Name</TableCell>
+          <TableCell>Status</TableCell>
+          <TableCell>Department</TableCell>
+          <TableCell>Private</TableCell>
+          <TableCell>Last edited</TableCell>
+          <TableCell>&nbsp;</TableCell>
         </TableRow>
-      </TableHeader>
-      <TableBody
-        showRowHover={true}
-        displayRowCheckbox={false}
-        className="Asset-table-body"
-      >
+      </TableHead>
+      <TableBody className="Asset-table-body">
         {
           // Display a "no assets" row if there is no loading happening and there are no assets.
           ((assetSummaries.length === 0) && !isLoadingAssets) ? <ZeroAssetsRow /> : null
@@ -59,9 +42,9 @@ AssetTable.propTypes = {
  */
 export const ZeroAssetsRow = () => (
   <TableRow>
-    <TableRowColumn colSpan={6} style={{textAlign: 'center'}}>
+    <TableCell colSpan={6} style={{textAlign: 'center'}}>
       There are no assets to display
-    </TableRowColumn>
+    </TableCell>
   </TableRow>
 );
 

--- a/src/components/AssetTableBody.js
+++ b/src/components/AssetTableBody.js
@@ -1,0 +1,44 @@
+import React from 'react'; // used implicitly by JSX
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { TableBody, TableCell, TableRow } from 'material-ui/Table';
+import AssetListItem from './AssetListItem';
+
+/**
+ * A table of assets.
+ */
+export const AssetTableBody = ({ summaries, isLoading = false }) => (
+  <TableBody className="Asset-table-body">
+    {
+      // Display a "no assets" row if there is no loading happening and there are no assets.
+      ((summaries.length === 0) && !isLoading) ? <ZeroAssetsRow /> : null
+    }
+    { summaries.map(({ url }) => <AssetListItem key={url} assetUrl={url} />) }
+  </TableBody>
+);
+
+AssetTableBody.propTypes = {
+  summaries: PropTypes.arrayOf(PropTypes.object).isRequired,
+  isLoading: PropTypes.bool,
+};
+
+/**
+ * Table row which is displayed when there are no assets in the current list.
+ */
+export const ZeroAssetsRow = () => (
+  <TableRow>
+    <TableCell colSpan={6} style={{textAlign: 'center'}}>
+      There are no assets to display
+    </TableCell>
+  </TableRow>
+);
+
+// Export unconnected version of component to ease testing
+export const UnconnectedAssetTableBody = AssetTableBody;
+
+const mapStateToProps = ({ assets: { summaries, isLoading } }) => ({
+  summaries, isLoading
+});
+
+export default connect(mapStateToProps)(AssetTableBody);
+

--- a/src/components/AssetTableHeader.js
+++ b/src/components/AssetTableHeader.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { getAssets, Direction } from '../redux/actions/assetRegisterApi';
+import { TableRow, TableCell, TableSortLabel, TableHead } from 'material-ui/Table';
+
+// A map from sort directions to values for the "direction" prop of TableSortLabel.
+const directionDescriptions = new Map([
+  [Direction.ascending, 'asc'], [Direction.descending, 'desc']
+]);
+
+// Given the current assets list query and the field name corresponding to a column, return the
+// query which should be run if that column's header is clicked.
+const getNextQuery = (query, field) => {
+  const { sort: { field: sortField, direction } } = query;
+  if(sortField !== field) {
+    return {...query, sort: { field, direction: Direction.ascending } };
+  } else {
+    // the current query sorts by this field, change the direction
+    const newDirection =
+        direction === Direction.ascending ? Direction.descending : Direction.ascending;
+    return {...query, sort: { field, direction: newDirection } };
+  }
+}
+
+/**
+ * A table heading cell which shows if the current asset list is sorted by a particular field and,
+ * if so, in which direction.
+ */
+const UnconnectedSortCell = ({ direction, active, label, nextQuery, getAssets }) => (
+  <TableCell sortDirection={active ? direction : false}>
+    <TableSortLabel onClick={() => getAssets(nextQuery)} active={active} direction={direction}>
+      {label}
+    </TableSortLabel>
+  </TableCell>
+);
+
+// IMPORTANT: Since SortCell makes use of animations via the CSS transition property, we need to
+// make sure to give the component as simple props as possible in order to maximise React's
+// likelihood of not re-creating the underlying DOM element but simply modifying its content.
+//
+// The list of props here were empirically determined to be "simple enough" to cause the nice
+// animation to show.
+//
+// This has the nice side-effect that the implementation of the AssetTableHeader component itself
+// is entirely stateless.
+const mapStateToProps = ({ assets: { query } }, { label, field }) => {
+  const { sort } = query;
+  const active = sort.field === field;
+  const direction = directionDescriptions.get(sort.direction);
+  return { direction, active, label, nextQuery: getNextQuery(query, field) };
+};
+
+const mapDispatchToProps = { getAssets };
+
+const SortCell = connect(mapStateToProps, mapDispatchToProps)(UnconnectedSortCell);
+
+SortCell.propTypes = {
+  field: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+};
+
+/**
+ * A component which provides the header row for the asset table. Heading titles can be used to
+ * change sort order.
+ *
+ */
+export const AssetTableHeader = () => (
+  <TableHead>
+    <TableRow>
+      <SortCell field='name' label='Name' />
+      <SortCell field='is_complete' label='Status' />
+      <SortCell field='department' label='Department' />
+      <SortCell field='private' label='Private' />
+      <SortCell field='updated_at' label='Last edited' />
+      <TableCell>&nbsp;</TableCell>
+    </TableRow>
+  </TableHead>
+);
+
+export default AssetTableHeader;

--- a/src/components/BooleanChoice.js
+++ b/src/components/BooleanChoice.js
@@ -1,32 +1,28 @@
 import React from 'react'
-import { RadioButtonGroup, RadioButton } from 'material-ui';
+import PropTypes from 'prop-types';
+import Radio, { RadioGroup } from 'material-ui/Radio';
+import { FormControlLabel } from 'material-ui/Form';
+import { withStyles } from 'material-ui/styles';
 
-const groupStyle = {
-  display: 'flex',
-  borderLeft: '1px solid #d1d1d1'
-};
-
-const buttonStyle = {
-  width: 'auto',
-  borderWidth: '1px 1px 1px 0',
-  borderStyle: 'solid',
-  borderColor: '#d1d1d1',
-  padding: "10px 20px"
+const styles = {
+  buttonStyle: {
+    backgroundColor: 'white',
+    paddingRight: 15,
+  },
 };
 
 /*
   A component implementing a yes/no choice and updating a boolean in state.
   */
-const BooleanChoice = (props) => (
-  <RadioButtonGroup
-    name={props.name}
-    valueSelected={props.value}
-    onChange={props.onChange}
-    style={groupStyle}
-  >
-    <RadioButton value={true} label="yes" style={buttonStyle} />
-    <RadioButton value={false} label="no" style={buttonStyle} />
-  </RadioButtonGroup>
+const BooleanChoice = ({ name, value, onChange, classes }) => (
+  <RadioGroup name={name} value={value ? "true" : "false"} onChange={onChange} row>
+    <FormControlLabel value="true" label="yes" control={<Radio />} className={classes.buttonStyle} />
+    <FormControlLabel value="false" label="no" control={<Radio />} className={classes.buttonStyle} />
+  </RadioGroup>
 );
 
-export default BooleanChoice
+BooleanChoice.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(BooleanChoice);

--- a/src/components/CheckboxGroup.js
+++ b/src/components/CheckboxGroup.js
@@ -1,18 +1,18 @@
-import React, {Component} from 'react'
-import { Checkbox } from 'material-ui';
+import React from 'react'
+import {
+    FormLabel,
+    FormControl,
+    FormGroup,
+    FormControlLabel,
+} from 'material-ui/Form';
+import Checkbox from 'material-ui/Checkbox';
+import { withStyles } from 'material-ui/styles';
 
-const containerStyle = {
-  borderTop: '1px solid #d1d1d1',
-  borderLeft: '1px solid #d1d1d1'
-};
-
-const itemStyle = {
-  borderBottom: '1px solid #d1d1d1',
-  borderRight: '1px solid #d1d1d1'
-};
-
-const titleStyle = {
-  padding: '30px 0 20px'
+const styles = {
+  labelStyle: {
+    backgroundColor: 'white',
+    margin: 1,
+  },
 };
 
 /*
@@ -20,39 +20,34 @@ const titleStyle = {
   and a values property (the initially selected values). As a Checkbox is checked/unchecked the values property is
   updated and the parents onChange method is called to update the state.
   */
-class CheckboxGroup extends Component {
+const CheckboxGroup = (
+  { name, title, labels, values, disabled = false, onChange = () => null, classes }
+) => {
+  const valueSet = new Set(values);
 
-  updateCheck(event, value) {
-    let index = this.props.values.indexOf(value);
-    if (index === -1) {
-      this.props.values.push(value);
-    } else {
-      this.props.values.splice(index, 1);
-    }
-    this.props.onChange(event, this.props.values);
-  }
-
-  render() {
-    var checkboxes = this.props.labels.map((item) => {
-      return <div key={item.value} className='App-grid-item' style={itemStyle}>
-          <Checkbox
-          label={item.label}
-          name={this.props.name}
-          disabled={this.props.disabled}
-          checked={this.props.values.indexOf(item.value) !== -1}
-          onCheck={(event) => this.updateCheck(event, item.value)}
-          />
-        </div>
-    });
-    return (
-      <div>
-        {this.props.title ? <div style={ titleStyle }>{this.props.title}</div> : ""}
-        <div style={ containerStyle } className={"App-grid-container App-grid-" + (this.props.columns ? this.props.columns : '1')}>
-          {checkboxes}
-        </div>
-      </div>
-    )
-  };
+  return (
+    <FormControl component="fieldset">
+      <FormLabel component="legend">{ title }</FormLabel>
+      <FormGroup>
+        {
+          labels.map(({ value, label }, index) => (
+            <FormControlLabel
+              key={index}
+              className={classes.labelStyle}
+              disabled={disabled}
+              control={<Checkbox />} checked={valueSet.has(value)}
+              label={label}
+              onChange={({ target: { checked } }) => {
+                const newValues = new Set(values);
+                if(checked) { newValues.add(value) } else { newValues.delete(value) }
+                onChange({ target: { name, value: [...newValues] } });
+              }}
+            />
+          ))
+        }
+      </FormGroup>
+    </FormControl>
+  );
 }
 
-export default CheckboxGroup
+export default withStyles(styles)(CheckboxGroup);

--- a/src/components/DeleteConfirmationDialog.js
+++ b/src/components/DeleteConfirmationDialog.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Dialog from 'material-ui/Dialog';
-import FlatButton from 'material-ui/FlatButton';
+import Dialog, {
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+} from 'material-ui/Dialog';
+import { Button } from 'material-ui';
 import { connect } from 'react-redux';
 import { deleteAsset } from '../redux/actions/assetRegisterApi';
 import { handleConfirmDelete } from '../redux/actions/deleteConfirmation';
@@ -11,22 +16,29 @@ import { handleConfirmDelete } from '../redux/actions/deleteConfirmation';
  *
  * The dialogue box is "open" when the URL of the asset being considered for deletion is truthy.
  */
-const DeleteConfirmationDialog = ({ url, name, deleteAsset, handleConfirmDelete }) => {
-  const actions = [
-    <FlatButton label="Cancel" primary={false}
-      onClick={() => handleConfirmDelete(url)} />,
-    <FlatButton label="Delete" primary={true}
-      onClick={() => { deleteAsset(url); handleConfirmDelete(url); }} />,
-  ];
-  return (
-    <Dialog modal={true} open={!!url} actions={actions}>
-      Delete <strong>"{ name }"</strong>?
-    </Dialog>
-  );
-};
+const DeleteConfirmationDialog = ({ url, name, id, deleteAsset, handleConfirmDelete }) => (
+  <Dialog open={!!url}>
+    <DialogTitle>Delete Asset Permanently?</DialogTitle>
+    <DialogContent>
+      <DialogContentText>
+        Once deleteted, the asset <strong>"{ name ? name : id }"</strong> cannot be recovered.
+      </DialogContentText>
+    </DialogContent>
+    <DialogActions>
+      <Button color="primary" onClick={() => handleConfirmDelete(url)}>
+        Cancel
+      </Button>
+      <Button color="primary" onClick={() => { deleteAsset(url); handleConfirmDelete(url); }}>
+        Delete
+      </Button>
+    </DialogActions>
+  </Dialog>
+);
 
 DeleteConfirmationDialog.propTypes = {
-  asset: PropTypes.object,
+  url: PropTypes.string,
+  name: PropTypes.string,
+  id: PropTypes.string,
   deleteAsset: PropTypes.func.isRequired,
   handleConfirmDelete: PropTypes.func.isRequired,
 };
@@ -34,8 +46,8 @@ DeleteConfirmationDialog.propTypes = {
 const mapStateToProps = ({ assets: { assetsByUrl }, deleteConfirmation: { url } }) => {
   // The asset which is being considered for deletion.
   const assetRecord= assetsByUrl.get(url);
-  const { name } = assetRecord ? assetRecord.asset : { };
-  return { url, name };
+  const { name, id } = assetRecord ? assetRecord.asset : { };
+  return { url, name, id };
 };
 
 const mapDispatchToProps = { deleteAsset, handleConfirmDelete };

--- a/src/components/GetMoreAssets.js
+++ b/src/components/GetMoreAssets.js
@@ -1,7 +1,7 @@
 import React from 'react'; // used implicitly by JSX
 import PropTypes from 'prop-types';
 import VisibilitySensor from 'react-visibility-sensor';
-import CircularProgress from 'material-ui/CircularProgress';
+import { CircularProgress } from 'material-ui/Progress';
 import { getMoreAssets } from '../redux/actions/assetRegisterApi';
 import { connect } from 'react-redux';
 

--- a/src/components/LoginButton.js
+++ b/src/components/LoginButton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { RaisedButton } from 'material-ui';
+import { Button } from 'material-ui';
 import { login, logout } from '../redux/actions';
 
 /**
@@ -10,9 +10,9 @@ import { login, logout } from '../redux/actions';
  */
 const LoginButton = ({ isLoggedIn, login, logout }) => {
   if (isLoggedIn) {
-    return <RaisedButton type='RaisedButton' onClick={logout}>Sign Out</RaisedButton>
+    return <Button variant="raised" type='Button' onClick={logout}>Sign Out</Button>
   } else {
-    return <RaisedButton type='RaisedButton' onClick={login}>Sign In</RaisedButton>
+    return <Button variant="raised" type='Button' onClick={login}>Sign In</Button>
   }
 };
 

--- a/src/components/Lookup.js
+++ b/src/components/Lookup.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react'
-import {AutoComplete} from 'material-ui';
+import {TextField} from 'material-ui';
 import _ from "underscore";
 import config from '../config';
 
@@ -66,15 +66,9 @@ class Lookup extends Component {
 
   render() {
     return (
-      <AutoComplete
+      <TextField
         disabled={this.props.disabled}
-        hintText={this.props.hintText}
-        searchText={this.state.displayName}
-        filter={AutoComplete.noFilter}
-        dataSource={this.state.matchingUsers}
-        dataSourceConfig={{text: 'visibleName', value: 'identifier.value'}}
-        onUpdateInput={(searchText) => this.handleOwnerUpdateInput(searchText)}
-        onNewRequest={(chosenRequest) => this.props.onChange({target: {name: this.props.name}}, chosenRequest.identifier.value)}
+        helperText={this.props.helperText}
       />
     )
   };

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -8,7 +8,7 @@ import LogoutLink from './LogoutLink'
   Renders the IAR application side bar.
  */
 const Sidebar = () => (
-  <Drawer open={true}>
+  <Drawer variant="permanent">
     <img src={logo} className="App-logo" alt="logo" />
     <h3>Assets</h3>
     <ul>

--- a/src/components/Snackbar.js
+++ b/src/components/Snackbar.js
@@ -5,8 +5,10 @@ import { snackbarClose } from '../redux/actions/snackbar';
 
 const Snackbar = ({ isOpen, message, snackbarClose }) => (
   <MuiSnackbar
-    open={isOpen} message={message} autoHideDuration={3000}
-    onRequestClose={snackbarClose}
+    open={isOpen} anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    message={message}
+    autoHideDuration={3000}
+    onClose={snackbarClose}
   />
 );
 

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom'
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
 import Snackbar from '../components/Snackbar';
 import PropTypes from 'prop-types';
 import AppRoutes from './AppRoutes';
@@ -9,12 +9,14 @@ import DeleteConfirmationDialog from '../components/DeleteConfirmationDialog';
 import ScrollToTop from '../components/ScrollToTop';
 import '../style/App.css';
 
+const theme = createMuiTheme();
+
 /*
   IAR main app component.
   */
 const App = ({ store }) => (
-  <Provider store={ store }>
-    <MuiThemeProvider>
+  <MuiThemeProvider theme={theme}>
+    <Provider store={ store }>
       <div>
         <Router>
           <ScrollToTop>
@@ -24,8 +26,8 @@ const App = ({ store }) => (
         <DeleteConfirmationDialog />
         <Snackbar />
       </div>
-    </MuiThemeProvider>
-  </Provider>
+    </Provider>
+  </MuiThemeProvider>
 );
 
 App.propTypes = {

--- a/src/containers/AppRoutes.test.js
+++ b/src/containers/AppRoutes.test.js
@@ -2,10 +2,14 @@
 import '../test/mocks';
 
 import React from 'react';
-import { AppBar } from 'material-ui';
+import { AppBar, Typography } from 'material-ui';
 import { render } from '../testutils';
 import AppRoutes from './AppRoutes';
 import NotFoundPage from './NotFoundPage';
+
+const appBarTitle = testInstance => (
+  testInstance.findByType(AppBar).findByType(Typography).props.children
+);
 
 /**
  * Simple unit test which assert that routes generate pages with the correct titles.
@@ -14,49 +18,49 @@ import NotFoundPage from './NotFoundPage';
 test('can render /static/what-is-asset', () => {
   const testInstance = render(<AppRoutes/>, {url: '/static/what-is-asset'});
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('What is an information asset?')
+  expect(appBarTitle(testInstance)).toBe('What is an information asset?')
 });
 
 test('can render /static/what-i-do', () => {
   const testInstance = render(<AppRoutes/>, {url: '/static/what-i-do'});
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('What do I need to do?')
+  expect(appBarTitle(testInstance)).toBe('What do I need to do?')
 });
 
 test('can render /static/feedback', () => {
   const testInstance = render(<AppRoutes/>, {url: '/static/feedback'});
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('Feedback')
+  expect(appBarTitle(testInstance)).toBe('Feedback')
 });
 
 test('can render /static/contact', () => {
   const testInstance = render(<AppRoutes/>, {url: '/static/contact'});
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('Contact')
+  expect(appBarTitle(testInstance)).toBe('Contact')
 });
 
 test('can render /static/tcs', () => {
   const testInstance = render(<AppRoutes/>, {url: '/static/tcs'});
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('Terms & Conditions')
+  expect(appBarTitle(testInstance)).toBe('Terms & Conditions')
 });
 
 test('can render /assets/dept', () => {
   const testInstance = render(<AppRoutes/>, {url: '/assets/dept'});
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('Assets: My department')
+  expect(appBarTitle(testInstance)).toBe('Assets: My department')
 });
 
 test('can render /assets/all', () => {
   const testInstance = render(<AppRoutes/>, {url: '/assets/all'});
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('Assets: All')
+  expect(appBarTitle(testInstance)).toBe('Assets: All')
 });
 
 test('/ redirects to /assets/dept', () => {
   const testInstance = render(<AppRoutes/>, {url: '/'});
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('Assets: My department')
+  expect(appBarTitle(testInstance)).toBe('Assets: My department')
 });
 
 test('/this-does-not-exist renders a not found page', () => {

--- a/src/containers/AssetForm.js
+++ b/src/containers/AssetForm.js
@@ -1,12 +1,19 @@
-import React, { Component } from 'react'
-import { RadioButton, RadioButtonGroup, TextField } from 'material-ui';
 import config from '../config';
-import { AssetFormHeader, BooleanChoice, CheckboxGroup, Lookup } from '../components'
+import React, { Component } from 'react'
+
 import Page from '../containers/Page';
+import Radio, { RadioGroup } from 'material-ui/Radio';
+import { TextField } from 'material-ui';
+import { AssetFormHeader, BooleanChoice, CheckboxGroup, Lookup } from '../components'
+import Grid from 'material-ui/Grid';
+import Switch from 'material-ui/Switch';
+import { FormControlLabel } from 'material-ui/Form';
+
 import { connect } from 'react-redux';
 import { snackbarOpen } from '../redux/actions/snackbar';
 
-const ACCESS_TOKEN = 'THIS IS A PLACEHOLDER';
+const ACCESS_TOKEN =
+  'PBi2W7PuYQ6RU4LLW-kVYfACXNAYPt6KXVNcQ0ivkUc.oN2ZYkfzYtE8-bF3dBE_3Nx_PPMvQMQtJeq_Vp_yBDg';
 
 const DATA_SUBJECT_LABELS = [
   {value: "staff", label: "Staff & applicants"},
@@ -67,19 +74,6 @@ const retentionStyle = {
   padding: '10px 20px'
 };
 
-const storageFormatGroupStyle = {
-  display: 'flex',
-  borderLeft: '1px solid #d1d1d1'
-};
-
-const storageFormatButtonStyle = {
-  width: 'auto',
-  borderWidth: '1px 1px 1px 0',
-  borderStyle: 'solid',
-  borderColor: '#d1d1d1',
-  padding: "10px 20px"
-};
-
 /*
   Renders the form for the creation/editing of an Asset.
   */
@@ -87,8 +81,6 @@ class AssetForm extends Component {
 
   constructor() {
     super();
-
-    this.handleChange = this.handleChange.bind(this);
 
     this.state = {
       // asset state
@@ -104,7 +96,6 @@ class AssetForm extends Component {
       recipients_category: null,
       recipients_outside_eea: null,
       retention: null,
-      retention_other: null,
       risk_type: [],
       storage_location: null,
       storage_format: [],
@@ -147,15 +138,6 @@ class AssetForm extends Component {
   }
 
   /*
-  Function trigger by the onChange of most inputs - updates state.
-   */
-  handleChange(event, value) {
-    let state = {};
-    state[event.target.name] = value === "" ? null : value;
-    this.setState(state);
-  }
-
-  /*
   Either creates a new asset or updates an existing one depending on the mode of the form.
    */
   handleSave() {
@@ -178,6 +160,20 @@ class AssetForm extends Component {
   }
 
   render() {
+    const nullToBlank = v => ( v === null ? '' : v );
+
+    const onChange = ({ target: { name, value } }) => {
+      this.setState({ [name]: value === '' ? null : value });
+    }
+
+    const onBooleanChange = ({ target: { name, value } }) => {
+      onChange({ target: { name, value: value === "true" } })
+    };
+
+    const onCheckboxChange = ({ target: { name } }, checked) => (
+      onChange({ target: { name, value: checked } })
+    );
+
     return (
       <Page>
         <AssetFormHeader
@@ -185,192 +181,242 @@ class AssetForm extends Component {
           title={this.props.match.url === '/asset/create' ? 'Create new asset' : 'Editing: ' + this.state.name}
         />
 
-        <div>
-          <div className="App-grid-container App-grid-2">
-            <div className="App-grid-item">
-              <TextField
-                hintText="Asset name"
-                name='name'
-                value={this.state.name === null ? "" : this.state.name}
-                onChange={this.handleChange}
-              />
-            </div>
-            <div className="App-grid-item">
-              <TextField
-                hintText="Asset department"
-                name='department'
-                value={this.state.department === null ? "" : this.state.department}
-                onChange={this.handleChange}
-              />
-            </div>
-            <div className="App-grid-item">
-              <TextField
-                hintText="Purpose of holding this asset"
-                name='purpose'
-                value={this.state.purpose === null ? "" : this.state.purpose}
-                onChange={this.handleChange}
-              />
-            </div>
-            <div className="App-grid-item"/>
-            <div className="App-grid-item">
-              Is this for research purposes?
-            </div>
-            <div className="App-grid-item">
-              <BooleanChoice name="research" value={this.state.research} onChange={this.handleChange} />
-            </div>
-            <div className="App-grid-item">
-              <Lookup
-                disabled={!this.state.research}
-                hintText="Principle Investigator"
-                name="owner"
-                value={this.state.owner}
-                onChange={this.handleChange}
-                fetch={this.fetch}
-              />
-            </div>
-            <div className="App-grid-item"/>
-            <div className="App-grid-item">
-              Is this data private to the department?
-            </div>
-            <div className="App-grid-item">
-              <BooleanChoice name="private" value={this.state.private} onChange={this.handleChange} />
-            </div>
-            <div className="App-grid-item">
-              Does this asset hold any Personal Data?
-            </div>
-            <div className="App-grid-item">
-              <BooleanChoice name="personal_data" value={this.state.personal_data} onChange={this.handleChange} />
-            </div>
-          </div>
+        <Grid container>
+          <Grid item xs={6}>
+            <TextField
+              fullWidth
+              label="Asset name"
+              helperText={
+                "Give the asset a unique name so you can easily identify it, for example, " +
+                "'Visting academics database'."
+              }
+              name='name'
+              value={nullToBlank(this.state.name)}
+              onChange={onChange}
+              margin="normal"
+            />
+          </Grid>
+          <Grid item xs={6}>
+            <TextField
+              fullWidth
+              label="Asset purpose"
+              helperText={
+                "For example, 'To keep a record of current and former staff and salaries for HR " +
+                "purposes'."
+              }
+              name='purpose'
+              value={nullToBlank(this.state.purpose)}
+              onChange={onChange}
+              margin="normal"
+            />
+          </Grid>
+        </Grid>
+        <Grid container>
+          <Grid item xs={6}>
+            <TextField
+              fullWidth
+              label="Asset department"
+              name='department'
+              value={nullToBlank(this.state.department)}
+              onChange={onChange}
+              margin="normal"
+            />
+          </Grid>
+          <Grid item xs={6}>
+            {/* The "===" true is necessary since private could also be null */}
+            <FormControlLabel
+              control={<Switch />}
+              checked={this.state.private === true}
+              label="Make this record private to your deparment"
+              margin="normal"
+              name="private"
+              onChange={onCheckboxChange}
+            />
+          </Grid>
+        </Grid>
+        <Grid container>
+          <Grid item xs={6}>
+            Is this asset retained for research purposes?
+          </Grid>
+          <Grid item xs={6}>
+            <BooleanChoice name="research" value={this.state.research} onChange={onBooleanChange} />
+          </Grid>
+          <Grid item xs={6}>
+            Who is the Principle Investigator of this research activity?
+          </Grid>
+          <Grid item xs={6}>
+            <Lookup
+              disabled={!this.state.research}
+              label="Principle Investigator"
+              helperText="You can search by name or CRSid"
+              name="owner"
+              value={this.state.owner}
+              onChange={onChange}
+              fetch={this.fetch}
+            />
+          </Grid>
+        </Grid>
 
-          <CheckboxGroup
-            title='Who does this Personal Data belong to?'
-            name='data_subject'
-            labels={DATA_SUBJECT_LABELS}
-            values={this.state.data_subject}
-            onChange={this.handleChange}
-            disabled={!this.state.personal_data}
-          />
+        <Grid container>
+          <Grid item xs={6}>
+            Does this asset hold any Personal Data?
+          </Grid>
+          <Grid item xs={6}>
+            <BooleanChoice name="personal_data" value={this.state.personal_data}
+              onChange={onBooleanChange} />
+          </Grid>
+        </Grid>
 
-          <CheckboxGroup
-            title='What kind of personal data is held?'
-            name='data_category'
-            labels={DATA_CATEGORY_LABELS}
-            values={this.state.data_category}
-            onChange={this.handleChange}
-            columns="2"
-            disabled={!this.state.personal_data}
-          />
+        <Grid container>
+          <Grid item xs={12}>
+            <CheckboxGroup
+              title='Who does this personal data belong to?'
+              name='data_subject'
+              labels={DATA_SUBJECT_LABELS}
+              values={this.state.data_subject}
+              onChange={onChange}
+              disabled={!this.state.personal_data}
+            />
+          </Grid>
+        </Grid>
 
-          <div className="App-grid-container App-grid-2">
-            <div className="App-grid-item">
-              <TextField
-                hintText="Who is the asset shared with?"
-                name='recipients_category'
-                value={this.state.recipients_category === null ? "" : this.state.recipients_category}
-                onChange={this.handleChange}
-                disabled={!this.state.personal_data}
-              />
-            </div>
-            <div className="App-grid-item">
-              <TextField
-                hintText="Is the asset shared outside of the EEA? If so, to whom?"
-                name='recipients_outside_eea'
-                value={this.state.recipients_outside_eea === null ? "" : this.state.recipients_outside_eea}
-                onChange={this.handleChange}
-                disabled={!this.state.personal_data}
-                style={{ width: 400 }}
-              />
-            </div>
-          </div>
+        <Grid container>
+          <Grid item xs={12}>
+            <CheckboxGroup
+              title='What kind of personal data is held?'
+              name='data_category'
+              labels={DATA_CATEGORY_LABELS}
+              values={this.state.data_category}
+              onChange={onChange}
+              columns="2"
+              disabled={!this.state.personal_data}
+            />
+          </Grid>
+        </Grid>
 
-          <div style={{padding: '20px 0'}}>How long will this asset be retained for?</div>
-          <div className="App-grid-container App-grid-1">
-            <RadioButtonGroup
+        <Grid container>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              margin="normal"
+              label="Which organisations is the asset shared with external to the University?"
+              helperText="This could be a company or individual."
+              name='recipients_category'
+              value={this.state.recipients_category === null ? "" : this.state.recipients_category}
+              onChange={onChange}
+              disabled={!this.state.personal_data}
+            />
+          </Grid>
+        </Grid>
+
+        <Grid container>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              margin="normal"
+              label="Is the asset shared outside of the EEA (European Economic Area)?"
+              helperText={
+                "This could be a company or an individual. More information regards the " +
+                "EEA can be found here."
+              }
+              name='recipients_outside_eea'
+              value={this.state.recipients_outside_eea === null ? "" : this.state.recipients_outside_eea}
+              onChange={onChange}
+              disabled={!this.state.personal_data}
+            />
+          </Grid>
+        </Grid>
+
+        <Grid container>
+          <Grid item xs={12}>
+            <div style={{padding: '20px 0'}}>How long will this asset be retained for?</div>
+            <RadioGroup
               name="retention"
-              valueSelected={this.state.retention}
-              onChange={this.handleChange}
+              value={this.state.retention}
+              onChange={onChange}
             >
-              <RadioButton disabled={!this.state.personal_data} style={retentionStyle}
+              <FormControlLabel control={<Radio />} disabled={!this.state.personal_data} style={retentionStyle}
                            value="<=1" label="Less than 1 year" />
-              <RadioButton disabled={!this.state.personal_data} style={retentionStyle}
+              <FormControlLabel control={<Radio />} disabled={!this.state.personal_data} style={retentionStyle}
                            value=">1,<=5" label="1 - 5 years" />
-              <RadioButton disabled={!this.state.personal_data} style={retentionStyle}
+              <FormControlLabel control={<Radio />} disabled={!this.state.personal_data} style={retentionStyle}
                            value=">5,<=10" label="6 - 10 years" />
-              <RadioButton disabled={!this.state.personal_data} style={retentionStyle}
+              <FormControlLabel control={<Radio />} disabled={!this.state.personal_data} style={retentionStyle}
                            value=">10,<=75" label="10 - 75 years" />
-              <RadioButton disabled={!this.state.personal_data} style={retentionStyle}
+              <FormControlLabel control={<Radio />} disabled={!this.state.personal_data} style={retentionStyle}
                            value="forever" label="Forever" />
-              <RadioButton disabled={!this.state.personal_data} style={{...retentionStyle, borderWidth: '1px'}}
-                           value="other" label="Other"  />
-            </RadioButtonGroup>
-          </div>
+            </RadioGroup>
+          </Grid>
+        </Grid>
 
-          <div className="App-grid-container App-grid-1">
-            <div className="App-grid-item">
-              <TextField
-                hintText="Other retention period"
-                name="retention_other"
-                disabled={this.state.retention !== 'other'}
-                value={this.state.retention_other === null ? "" : this.state.retention_other}
-                onChange={this.handleChange}
-              />
-            </div>
-          </div>
+        <Grid container>
+          <Grid item xs={12}>
+            <CheckboxGroup
+              title='What are the risks if the information in this asset was lost or compromised?'
+              name="risk_type"
+              labels={RISK_TYPE_LABELS}
+              values={this.state.risk_type}
+              onChange={onChange}
+            />
+          </Grid>
+        </Grid>
 
-          <CheckboxGroup
-            title='What are the risks of holding this information asset?'
-            name="risk_type"
-            labels={RISK_TYPE_LABELS}
-            values={this.state.risk_type}
-            onChange={this.handleChange}
-          />
+        <Grid container>
+          <Grid item xs={12}>
+            <TextField
+              fullWidth
+              margin="normal"
+              label="Where is the asset stored?"
+              helperText={
+                "For example, on a virtual machine, in a shared drive, in cloud storage. " +
+                "Ask your compuuter officer if you're not sure."
+              }
+              name="storage_location"
+              value={this.state.storage_location === null ? "" : this.state.storage_location}
+              onChange={onChange}
+            />
+          </Grid>
+        </Grid>
 
-          <div className="App-grid-container App-grid-1">
-            <div className="App-grid-item">
-              <TextField
-                hintText="Where is the asset stored?"
-                name="storage_location"
-                value={this.state.storage_location === null ? "" : this.state.storage_location}
-                onChange={this.handleChange}
-              />
-            </div>
-          </div>
+        <Grid container>
+          <Grid item xs={6}>
+            What format is the asset stored in?
+          </Grid>
+          <Grid item xs={6}>
+            <RadioGroup
+              row
+              name="storage_format"
+              value={this.state.storage_format.sort().toString()}
+              onChange={(event, value) => this.setState({storage_format: value.split(',')})}
+            >
+              <FormControlLabel control={<Radio />} value="digital" label="Digital" />
+              <FormControlLabel control={<Radio />} value="paper" label="Paper" />
+              <FormControlLabel control={<Radio />} value="digital,paper" label="Both" />
+            </RadioGroup>
+          </Grid>
+        </Grid>
 
-          <div className="App-grid-container App-grid-2">
-            <div className="App-grid-item">
-              What format is the asset stored in?
-            </div>
-            <div className="App-grid-item">
-              <RadioButtonGroup
-                name="storage_format"
-                valueSelected={this.state.storage_format.sort().toString()}
-                onChange={(event, value) => this.setState({storage_format: value.split(',')})}
-                style={storageFormatGroupStyle}
-              >
-                <RadioButton value="digital" label="Digital" style={storageFormatButtonStyle} />
-                <RadioButton value="paper" label="Paper" style={storageFormatButtonStyle} />
-                <RadioButton value="digital,paper" label="Both" style={storageFormatButtonStyle} />
-              </RadioButtonGroup>
-            </div>
-          </div>
-
-          <CheckboxGroup
-            title='What are the risks of holding this information asset?'
-            labels={DIGITAL_STORAGE_SECURITY_LABELS}
-            name="digital_storage_security"
-            values={this.state.digital_storage_security}
-            onChange={this.handleChange}
-            disabled={this.state.storage_format.indexOf("digital") === -1}
-          />
-          <CheckboxGroup
-            labels={PAPER_STORAGE_SECURITY_LABELS}
-            name="paper_storage_security"
-            values={this.state.paper_storage_security}
-            onChange={this.handleChange}
-            disabled={this.state.storage_format.indexOf("paper") === -1}
-          />
-        </div>
+        <Grid container>
+          <Grid item xs={12}>
+            <CheckboxGroup
+              title='How is the asset kept secure?'
+              labels={DIGITAL_STORAGE_SECURITY_LABELS}
+              name="digital_storage_security"
+              values={this.state.digital_storage_security}
+              onChange={onChange}
+              disabled={this.state.storage_format.indexOf("digital") === -1}
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <CheckboxGroup
+              labels={PAPER_STORAGE_SECURITY_LABELS}
+              name="paper_storage_security"
+              values={this.state.paper_storage_security}
+              onChange={onChange}
+              disabled={this.state.storage_format.indexOf("paper") === -1}
+            />
+          </Grid>
+        </Grid>
       </Page>
     )
   }

--- a/src/containers/AssetForm.test.js
+++ b/src/containers/AssetForm.test.js
@@ -1,13 +1,20 @@
 // mock any components which are troublesome in our test suite
 import '../test/mocks';
 
+// Mock configuration for endpoints
+jest.mock('../config', () => ({
+  ENDPOINT_ASSETS: 'http://localhost:8000/assets/',
+  ENDPOINT_LOOKUP: 'http://localhost:8080/',
+}));
+
 import React from 'react';
 import { Route } from 'react-router-dom'
 import fetch_mock from 'fetch-mock';
-import { AppBar, RadioButtonGroup, TextField } from 'material-ui';
+import { AppBar, RadioGroup, TextField, Typography, FormControlLabel } from 'material-ui';
 import { render, condition } from '../testutils';
 import { BooleanChoice, CheckboxGroup, Lookup } from '../components'
 import AppRoutes from './AppRoutes';
+import AssetFormHeader from '../components/AssetFormHeader';
 import { createMockStore } from '../testutils';
 import { SNACKBAR_OPEN } from '../redux/actions/snackbar';
 
@@ -23,8 +30,7 @@ const NEW_ASSET_FIXTURE = {
   data_category: [ 'sexual', 'medical', 'genetic', 'biometric' ],
   recipients_category: 'Addenbrookes',
   recipients_outside_eea: 'Not shared',
-  retention: 'other',
-  retention_other: 'Yonks',
+  retention: '<=1',
   risk_type: [ 'compliance', 'reputational', 'operational' ],
   storage_location: 'Under the stairs',
   storage_format: [ 'digital', 'paper' ],
@@ -50,6 +56,10 @@ fetch_mock.get('http://localhost:8080/people/crsid/mb2174', {
   visibleName: "M. Bamford",
 });
 
+const appBarTitle = testInstance => (
+  testInstance.findByType(AppBar).findByType(Typography).props.children
+);
+
 /*
   Tests that a form is rendered for /asset/create
  */
@@ -57,7 +67,7 @@ test('can route /asset/create', () => {
 
   const testInstance = render(<AppRoutes/>, {url: '/asset/create'});
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('Create new asset')
+  expect(appBarTitle(testInstance)).toBe('Create new asset')
 });
 
 /*
@@ -68,9 +78,9 @@ test('can route /asset/e20f4cd4-9f97-4829-8178-476c7a67eb97', async () => {
   const testInstance = render(<AppRoutes/>, {url: '/asset/e20f4cd4-9f97-4829-8178-476c7a67eb97'});
 
   // waits for the title to be populated. TODO better way to do this?
-  await condition(() => testInstance.findByType(AppBar).props.title);
+  await condition(() => appBarTitle(testInstance));
 
-  expect(testInstance.findByType(AppBar).props.title).toBe('Editing: Super Secret Medical Data')
+  expect(appBarTitle(testInstance)).toBe('Editing: Super Secret Medical Data')
 });
 
 /*
@@ -85,17 +95,16 @@ test('can render a blank form', () => {
   expect(testInstance.findByProps({name: 'purpose'}).type).toBe(TextField);
   expect(testInstance.findByProps({name: "research"}).type).toBe(BooleanChoice);
   expect(testInstance.findByProps({name: 'owner'}).type).toBe(Lookup);
-  expect(testInstance.findByProps({name: "private"}).type).toBe(BooleanChoice);
+  expect(testInstance.findByProps({name: "private"}).type).toBe(FormControlLabel);
   expect(testInstance.findByProps({name: "personal_data"}).type).toBe(BooleanChoice);
   expect(testInstance.findByProps({name: "data_subject"}).type).toBe(CheckboxGroup);
   expect(testInstance.findByProps({name: "data_category"}).type).toBe(CheckboxGroup);
   expect(testInstance.findByProps({name: 'recipients_category'}).type).toBe(TextField);
   expect(testInstance.findByProps({name: 'recipients_outside_eea'}).type).toBe(TextField);
-  expect(testInstance.findByProps({name: 'retention'}).type).toBe(RadioButtonGroup);
-  expect(testInstance.findByProps({name: 'retention_other'}).type).toBe(TextField);
+  expect(testInstance.findByProps({name: 'retention'}).type).toBe(RadioGroup);
   expect(testInstance.findByProps({name: "risk_type"}).type).toBe(CheckboxGroup);
   expect(testInstance.findByProps({name: 'storage_location'}).type).toBe(TextField);
-  expect(testInstance.findByProps({name: 'storage_format'}).type).toBe(RadioButtonGroup);
+  expect(testInstance.findByProps({name: 'storage_format'}).type).toBe(RadioGroup);
   expect(testInstance.findByProps({name: "digital_storage_security"}).type).toBe(CheckboxGroup);
   expect(testInstance.findByProps({name: "paper_storage_security"}).type).toBe(CheckboxGroup);
 });
@@ -108,24 +117,23 @@ test('can populate a form with data', async () => {
   const testInstance = render(<AppRoutes/>, {url: '/asset/e20f4cd4-9f97-4829-8178-476c7a67eb97'});
 
   // waits for the title to be populated.
-  await condition(() => testInstance.findByType(AppBar).props.title);
+  await condition(() => appBarTitle(testInstance));
 
   expect(testInstance.findByProps({name: 'name'}).props.value).toBe('Super Secret Medical Data');
   expect(testInstance.findByProps({name: 'department'}).props.value).toBe("Medicine");
   expect(testInstance.findByProps({name: 'purpose'}).props.value).toBe("Medical Research");
   expect(testInstance.findByProps({name: "research"}).props.value).toBeTruthy();
   expect(testInstance.findByProps({name: 'owner'}).props.value).toBe("mb2174");
-  expect(testInstance.findByProps({name: "private"}).props.value).toBeTruthy();
+  expect(testInstance.findByProps({name: "private"}).props.checked).toBeTruthy();
   expect(testInstance.findByProps({name: "personal_data"}).props.value).toBeTruthy();
   expect(testInstance.findByProps({name: "data_subject"}).props.values).toEqual(["patients"]);
   expect(testInstance.findByProps({name: "data_category"}).props.values).toEqual(["sexual", "medical", "genetic", "biometric"]);
   expect(testInstance.findByProps({name: 'recipients_category'}).props.value).toBe("Addenbrookes");
   expect(testInstance.findByProps({name: 'recipients_outside_eea'}).props.value).toBe("Not shared");
-  expect(testInstance.findByProps({name: 'retention'}).props.valueSelected).toBe("other");
-  expect(testInstance.findByProps({name: 'retention_other'}).props.value).toBe("Yonks");
+  expect(testInstance.findByProps({name: 'retention'}).props.value).toBe("<=1");
   expect(testInstance.findByProps({name: "risk_type"}).props.values).toEqual(["compliance", "reputational", "operational"]);
   expect(testInstance.findByProps({name: 'storage_location'}).props.value).toBe("Under the stairs");
-  expect(testInstance.findByProps({name: 'storage_format'}).props.valueSelected).toBe("digital,paper");
+  expect(testInstance.findByProps({name: 'storage_format'}).props.value).toBe("digital,paper");
   expect(testInstance.findByProps({name: "digital_storage_security"}).props.values).toEqual(["encryption", "acl"]);
   expect(testInstance.findByProps({name: "paper_storage_security"}).props.values).toEqual(["safe"]);
 });
@@ -165,16 +173,15 @@ test('can save a new asset', async () => {
   setDataOnInput(testInstance, 'name', 'Super Secret Medical Data');
   setDataOnInput(testInstance, 'department', "Medicine");
   setDataOnInput(testInstance, 'purpose', "Medical Research");
-  setDataOnInput(testInstance, 'research', true);
+  setDataOnInput(testInstance, 'research', "true");
   setDataOnInput(testInstance, 'owner', "mb2174");
   setDataOnInput(testInstance, 'private', true);
-  setDataOnInput(testInstance, 'personal_data', true);
+  setDataOnInput(testInstance, 'personal_data', "true");
   setDataOnInput(testInstance, 'data_subject', ["patients"]);
   setDataOnInput(testInstance, 'data_category', ["sexual", "medical", "genetic", "biometric"]);
   setDataOnInput(testInstance, 'recipients_category', "Addenbrookes");
   setDataOnInput(testInstance, 'recipients_outside_eea', "Not shared");
-  setDataOnInput(testInstance, 'retention', "other");
-  setDataOnInput(testInstance, 'retention_other', "Yonks");
+  setDataOnInput(testInstance, 'retention', "<=1");
   setDataOnInput(testInstance, 'risk_type', ["compliance",  "reputational", "operational"]);
   setDataOnInput(testInstance, 'storage_location', "Under the stairs");
   setDataOnInput(testInstance, 'storage_format', "digital,paper");
@@ -182,7 +189,7 @@ test('can save a new asset', async () => {
   setDataOnInput(testInstance, 'paper_storage_security', ["safe"]);
 
   // "click" the save button and wair for the response
-  testInstance.findByProps({label: 'Save'}).props.onClick();
+  testInstance.findByType(AssetFormHeader).props.onClick();
   await condition(() => store.getActions().filter(action => action.type === SNACKBAR_OPEN));
 
   const [ { payload: { message } } ] =
@@ -195,7 +202,6 @@ test('can save a new asset', async () => {
   Tests that an edited existing asset is saved with the correct data.
  */
 test('can update an asset', async () => {
-
   fetch_mock.put(function(url, opts) {
     expect(url).toEqual('http://localhost:8000/assets/e20f4cd4-9f97-4829-8178-476c7a67eb97/');
     // check for new value
@@ -207,12 +213,12 @@ test('can update an asset', async () => {
   const testInstance = render(<AppRoutes />, {store, url: '/asset/e20f4cd4-9f97-4829-8178-476c7a67eb97'});
 
   // waits for the title to be populated.
-  await condition(() => testInstance.findByType(AppBar).props.title);
+  await condition(() => appBarTitle(testInstance));
 
   setDataOnInput(testInstance, 'purpose', "Secret Medical Research");
 
-  // "click" the save button and wair for the response
-  testInstance.findByProps({label: 'Save'}).props.onClick();
+  // "click" the save button and wait for the response
+  testInstance.findByType(AssetFormHeader).props.onClick();
   await condition(() => store.getActions().filter(action => action.type === SNACKBAR_OPEN));
 
   const [ { payload: { message } } ] =
@@ -225,5 +231,5 @@ test('can update an asset', async () => {
   Helper for setting some data on an input component
  */
 function setDataOnInput(testInstance, name, value) {
-  testInstance.findByProps({name: name}).props.onChange({target: {name: name}}, value);
+  testInstance.findByProps({name: name}).props.onChange({target: {name: name, value}}, value);
 }

--- a/src/containers/AssetForm.test.js
+++ b/src/containers/AssetForm.test.js
@@ -46,7 +46,7 @@ fetch_mock.get(ASSET_FIXTURE_URL, ASSET_FIXTURE);
 
 // Required because asset form redirects to the index when the form has been saved and the index
 // will fetch the asset list.
-fetch_mock.get('http://localhost:8000/assets/', {
+fetch_mock.get('http://localhost:8000/assets/?ordering=-updated_at', {
   next: null, previous: null, results: [ ASSET_FIXTURE ],
 });
 

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -4,6 +4,7 @@ import AssetListHeader from '../components/AssetListHeader';
 import AssetTable from '../components/AssetTable';
 import Page from '../containers/Page';
 import GetMoreAssets from '../components/GetMoreAssets';
+import { withRouter } from 'react-router'
 
 import '../style/App.css';
 
@@ -30,4 +31,4 @@ AssetList.propTypes = {
   match: PropTypes.object.isRequired,
 };
 
-export default AssetList;
+export default withRouter(AssetList);

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -1,10 +1,12 @@
-import React from 'react'; // used implicitly by JSX
+import React, { Component } from 'react'; // used implicitly by JSX
 import PropTypes from 'prop-types';
 import AssetListHeader from '../components/AssetListHeader';
 import AssetTable from '../components/AssetTable';
 import Page from '../containers/Page';
 import GetMoreAssets from '../components/GetMoreAssets';
 import { withRouter } from 'react-router'
+import { connect } from 'react-redux';
+import { getAssets, Direction } from '../redux/actions/assetRegisterApi';
 
 import '../style/App.css';
 
@@ -13,22 +15,42 @@ const TITLES = {
   '/assets/all': 'Assets: All',
 };
 
-const AssetList = ({ match }) => (
-  <Page>
-    <AssetListHeader title={TITLES[match.url]} />
+class AssetList extends Component {
+  componentDidMount() {
+    const { getAssets, lastAssetListUrl } = this.props;
 
-    {/* Table of currently loaded assets. */}
-    <AssetTable />
+    // Fetch an asset list if one has not already been fetched. We detect a fetch by looking at the
+    // "url" property in the assets state which is exposed as the "lastAssetListUrl" prop.
+    if(!lastAssetListUrl) {
+      getAssets({ sort: { field: 'updated_at', direction: Direction.descending } });
+    }
+  }
 
-    <div style={{textAlign: 'center'}}>
-      {/* When this component becomes visible more assets are loaded to populate the table. */}
-      <GetMoreAssets />
-    </div>
-  </Page>
-);
+  render() {
+    const { match } = this.props;
+    return (
+      <Page>
+        <AssetListHeader title={TITLES[match.url]} />
+
+        {/* Table of currently loaded assets. */}
+        <AssetTable />
+
+        <div style={{textAlign: 'center'}}>
+          {/* When this component becomes visible more assets are loaded to populate the table. */}
+          <GetMoreAssets />
+        </div>
+      </Page>
+    );
+  }
+};
 
 AssetList.propTypes = {
   match: PropTypes.object.isRequired,
+  lastAssetListUrl: PropTypes.string,
 };
 
-export default withRouter(AssetList);
+const mapStateToProps = ({ assets: { url: lastAssetListUrl } }) => ({ lastAssetListUrl });
+
+const mapDispatchToProps = { getAssets };
+
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(AssetList));

--- a/src/containers/Static.js
+++ b/src/containers/Static.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { AppBar } from 'material-ui';
 import Page from '../containers/Page';
+import AppBar from 'material-ui/AppBar';
+import Toolbar from 'material-ui/Toolbar';
+import Typography from 'material-ui/Typography';
 
 const TITLES = {
   '/static/what-is-asset': 'What is an information asset?',
@@ -14,9 +16,13 @@ const TITLES = {
   Renders the app bar of the IAR app's static pages.
  */
 const StaticHeader = ({ title }) => (
-  <div className="App-header">
-    <AppBar title={ title } />
-  </div>
+  <AppBar position="static">
+    <Toolbar>
+      <Typography variant="title" color="inherit">
+        { title }
+      </Typography>
+    </Toolbar>
+  </AppBar>
 );
 
 /*

--- a/src/redux/actions/assetRegisterApi.js
+++ b/src/redux/actions/assetRegisterApi.js
@@ -1,4 +1,5 @@
 import { RSAA } from 'redux-api-middleware';
+import { ENDPOINT_ASSETS } from '../../config';
 
 export const ASSETS_LIST_REQUEST = Symbol('ASSETS_LIST_REQUEST');
 export const ASSETS_LIST_SUCCESS = Symbol('ASSETS_LIST_SUCCESS');
@@ -11,6 +12,104 @@ export const ASSETS_DELETE_FAILURE = Symbol('ASSETS_DELETE_FAILURE');
 export const ASSET_GET_REQUEST = Symbol('ASSET_GET_REQUEST');
 export const ASSET_GET_SUCCESS = Symbol('ASSET_GET_SUCCESS');
 export const ASSET_GET_FAILURE = Symbol('ASSET_GET_FAILURE');
+
+// Shared fields between FILTER_FIELDS and SORT_FIELDS.
+const COMMON_FIELDS = [
+  'id', 'name', 'department', 'purpose', 'owner', 'private', 'research', 'personal_data',
+  'data_subject', 'data_category', 'recipients_category', 'recipients_outside_eea', 'retention',
+  'risk_type', 'storage_location', 'storage_format', 'paper_storage_security', 'is_complete',
+  'digital_storage_security',
+];
+
+// Set of fields which can be used as a filter
+export const FILTER_FIELDS = new Set(COMMON_FIELDS);
+
+// Set of fields which can be used for sorting
+export const SORT_FIELDS = new Set([...COMMON_FIELDS, 'created_at', 'updated_at']);
+
+export const Direction = Object.freeze({
+  ascending: Symbol('ascending'), descending: Symbol('descending')
+});
+
+/**
+ * Fetch a new set of assets. Optionally passed an object containing the following properties:
+ *
+ * sort: (optional) object with following structure:
+ *
+ *  { field, direction }
+ *
+ *    field: (optional) String giving the field name which should be used for ordering the returned
+ *      results. By default the results are ordered by created_at. Must be one of the strings in
+ *      SORT_FIELDS. If sortBy is not in SORT_FIELDS, this is ignored. Default: created_at.
+ *
+ *    direction: (optional) One of Direction.ascending or Direction.descending depending on what
+ *      order the sorted results should be returned in. Invalid values are ignored. Default:
+ *      Direction.descending.
+ *
+ * search: (optional) String which should be matched against all asset fields.
+ *
+ * filter: (optional) Object whose properties specify filters. Only the properties in FILTER_FIELDS
+ *   are looked at. Other properties are ignored.
+ *
+ */
+export const getAssets = ({
+  sort: { field: sortBy = 'created_at', direction = Direction.descending } = { }, search, filter
+} = {}) => {
+  // Build a query string from the options passed to this action.
+
+  // Array of [key, value] pairs which are built into the query string.
+  const queryParts = [];
+
+  // Object representing this query in the state.
+  const query = { sort: { field: null, direction: null }, filter: { }, search: null };
+
+  // Add in search query
+  if(search) { queryParts.push(['search', search]); query.search = search; }
+
+  // If direction is not one of the expected values, it defaults to descending
+  switch(direction) {
+    case Direction.ascending:
+    case Direction.descending:
+      break;
+    default:
+      direction = Direction.descending;
+  }
+
+  // Add in sort by field
+  if(SORT_FIELDS.has(sortBy)) {
+    query.sort = { field: sortBy, direction: direction };
+    queryParts.push(['ordering', ((direction === Direction.descending) ? '-' : '') + sortBy]);
+  }
+
+  // Add in filter fields.
+  if(filter) {
+    Object.getOwnPropertyNames(filter)
+      .filter(propName => FILTER_FIELDS.has(propName))
+      .forEach(propName => {
+        queryParts.push([propName, filter[propName]]);
+        query.filter[propName] = filter[propName];
+      });
+  }
+
+  // Build the URL
+  const url = ENDPOINT_ASSETS + (
+    (queryParts.length > 0)
+    ? ('?' + queryParts.map(([key, value]) => key + '=' + encodeURIComponent(value)).join('&'))
+    : ''
+  );
+
+  return {
+    [RSAA]: {
+      endpoint: url,
+      method: 'GET',
+      types: [
+        { type: ASSETS_LIST_REQUEST, meta: { url, query } },
+        { type: ASSETS_LIST_SUCCESS, meta: { url, query } },
+        { type: ASSETS_LIST_FAILURE, meta: { url, query } },
+      ],
+    }
+  };
+};
 
 /**
  * Request more assets from the API. If URL corresponds to the "next" or "previous" URLs, the list

--- a/src/redux/actions/assetRegisterApi.test.js
+++ b/src/redux/actions/assetRegisterApi.test.js
@@ -1,0 +1,77 @@
+import { RSAA } from 'redux-api-middleware';
+import { getAssets, Direction } from './assetRegisterApi';
+import { ENDPOINT_ASSETS } from '../../config';
+
+// utility function which takes a URL, splits the query string and returns the base URL and query
+// string split at '&' characters into an array of 'xxx=yyy' strings. This is not a full URL parser
+// but is good enough for our needs. Returns an object of the form { baseUrl, queryItems }. If
+// there is no query string, queryItems is null.
+const splitUrl = url => {
+  const [ baseUrl, queryString ] = url.split('?', 2);
+  const queryItems = (queryString !== undefined) ? queryString.split('&') : null;
+  return { baseUrl, queryItems };
+};
+
+// call getAssets() with the passed arguments, calls splitUrl, checks the baseUrl is the assets
+// endpoint and returns the queryItems from splitUrl()
+const getAssetsAndParse = (...args) => {
+  const { [RSAA]: { endpoint = '' } } = getAssets(...args);
+  const { baseUrl, queryItems } = splitUrl(endpoint);
+  expect(baseUrl).toBe(ENDPOINT_ASSETS);
+  return queryItems;
+};
+
+test('simple call to getAssets just returns assets endpoint', () => {
+  const queryItems = getAssetsAndParse();
+  expect(queryItems).toHaveLength(1);
+  expect(queryItems).toContain('ordering=-created_at');
+});
+
+test('adding a search adds an appropriately encoded query parameter', () => {
+  const queryItems = getAssetsAndParse({ search: 'one two' });
+  expect(queryItems).toHaveLength(2);
+  expect(queryItems).toContain('ordering=-created_at');
+  expect(queryItems).toContain('search=one%20two');
+});
+
+test('can add sort field', () => {
+  const queryItems = getAssetsAndParse({ sort: { field: 'name' } });
+  expect(queryItems).toEqual(['ordering=-name']);
+});
+
+test('can add ascending sort field', () => {
+  const queryItems = getAssetsAndParse({ sort: { field: 'name', direction: Direction.ascending } });
+  expect(queryItems).toEqual(['ordering=name']);
+});
+
+test('can add descending sort field', () => {
+  const queryItems = getAssetsAndParse({ sort: { field: 'name', direction: Direction.descending } });
+  expect(queryItems).toEqual(['ordering=-name']);
+});
+
+test('invalid directions are ignored', () => {
+  const queryItems = getAssetsAndParse({ sort: { field: 'name', direction: 'RANDOM' } });
+  expect(queryItems).toEqual(['ordering=-name']);
+});
+
+test('Can filter by multiple fields with invalid ones being ignored', () => {
+  const queryItems = getAssetsAndParse({
+    filter: { name: 'xxx', department: 'yyy', badField: 'zzz', ordering: 'aaa', search: 'bbb' }
+  });
+  expect(queryItems).toHaveLength(3);
+  expect(queryItems).toContain('ordering=-created_at');
+  expect(queryItems).toContain('department=yyy');
+  expect(queryItems).toContain('name=xxx');
+});
+
+test('sort, search and filter can be combined together', () => {
+  const queryItems = getAssetsAndParse({
+    sort: { field: 'name', direction: Direction.descending }, search: 'one two',
+    filter: { name: 'a b c', department: 'd e f', no_such_field: 'zzz' }
+  });
+  expect(queryItems).toHaveLength(4);
+  expect(queryItems).toContain('search=one%20two');
+  expect(queryItems).toContain('ordering=-name');
+  expect(queryItems).toContain('department=d%20e%20f');
+  expect(queryItems).toContain('name=a%20b%20c');
+});

--- a/src/testutils.js
+++ b/src/testutils.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import TestRenderer from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
 import configureMockStore from 'redux-mock-store';
 import { middlewares } from './redux/enhancer';
 import { initialState as assetsInitialState } from './redux/reducers/assetRegisterApi';
@@ -28,9 +28,10 @@ export const createMockStore = (initialState = DEFAULT_INITIAL_STATE) => mockSto
  */
 const render = (component, {store, url} = {}) => {
   if(!store) { store = createMockStore(DEFAULT_INITIAL_STATE); }
+  const theme = createMuiTheme();
   let wrapped_component = (
     <Provider store={store}>
-      <MuiThemeProvider>
+      <MuiThemeProvider theme={theme}>
         { component }
       </MuiThemeProvider>
     </Provider>


### PR DESCRIPTION
**IMPORTANT:** This PR depends on #36 and includes d69e6a5 from that PR.

Add sorting to the asset list. Filtering would also be possible but there is no UI design for it yet so I've left it for another story. This is done with two commits:

e32351b adds a new action, getAssets, which fetches a new list of assets from the API with a query specifying search, sorting and filtering. When the request succeeds, the redux state is updated to record the query so that UI components can react.

afa34a7 adds some UI components which react to this change by re-factoring the AssetTable body and header into two components and making use of the new TableSortLabel component from MUI v1 to render a nice header.