### PR TITLE
add sorting to the asset list

### DIFF
--- a/src/components/AssetTable.js
+++ b/src/components/AssetTable.js
@@ -1,60 +1,18 @@
 import React from 'react'; // used implicitly by JSX
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-
-import Table, { TableBody, TableCell, TableHead, TableRow } from 'material-ui/Table';
-import AssetListItem from './AssetListItem';
+import Table from 'material-ui/Table';
+import AssetTableHeader from './AssetTableHeader';
+import AssetTableBody from './AssetTableBody';
 
 /**
  * A table of assets.
  */
-export const AssetTable = ({ assetSummaries, isLoadingAssets = false }) => (
+export const AssetTable = () => (
   <div className="Asset-table">
     <Table>
-      <TableHead>
-        <TableRow>
-          <TableCell>Name</TableCell>
-          <TableCell>Status</TableCell>
-          <TableCell>Department</TableCell>
-          <TableCell>Private</TableCell>
-          <TableCell>Last edited</TableCell>
-          <TableCell>&nbsp;</TableCell>
-        </TableRow>
-      </TableHead>
-      <TableBody className="Asset-table-body">
-        {
-          // Display a "no assets" row if there is no loading happening and there are no assets.
-          ((assetSummaries.length === 0) && !isLoadingAssets) ? <ZeroAssetsRow /> : null
-        }
-        { assetSummaries.map(({ url }) => <AssetListItem key={url} assetUrl={url} />) }
-      </TableBody>
+      <AssetTableHeader />
+      <AssetTableBody />
     </Table>
   </div>
 );
 
-AssetTable.propTypes = {
-  assetSummaries: PropTypes.arrayOf(PropTypes.object).isRequired,
-  isLoadingAssets: PropTypes.bool,
-};
-
-/**
- * Table row which is displayed when there are no assets in the current list.
- */
-export const ZeroAssetsRow = () => (
-  <TableRow>
-    <TableCell colSpan={6} style={{textAlign: 'center'}}>
-      There are no assets to display
-    </TableCell>
-  </TableRow>
-);
-
-// Export unconnected version of component to ease testing
-export const UnconnectedAssetTable = AssetTable;
-
-const mapStateToProps = ({
-  assets: { summaries: assetSummaries, isLoading: isLoadingAssets }
-}) => ({
-  assetSummaries, isLoadingAssets
-});
-
-export default connect(mapStateToProps)(AssetTable);
+export default AssetTable;

--- a/src/components/AssetTableBody.js
+++ b/src/components/AssetTableBody.js
@@ -1,0 +1,40 @@
+import React from 'react'; // used implicitly by JSX
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { TableBody, TableCell, TableRow } from 'material-ui/Table';
+import AssetListItem from './AssetListItem';
+
+/**
+ * A table of assets.
+ */
+export const UnconnectedAssetTableBody = ({ summaries, isLoading = false }) => (
+  <TableBody className="Asset-table-body">
+    {
+      // Display a "no assets" row if there is no loading happening and there are no assets.
+      ((summaries.length === 0) && !isLoading) ? <ZeroAssetsRow /> : null
+    }
+    { summaries.map(({ url }) => <AssetListItem key={url} assetUrl={url} />) }
+  </TableBody>
+);
+
+UnconnectedAssetTableBody.propTypes = {
+  summaries: PropTypes.arrayOf(PropTypes.object).isRequired,
+  isLoading: PropTypes.bool,
+};
+
+/**
+ * Table row which is displayed when there are no assets in the current list.
+ */
+export const ZeroAssetsRow = () => (
+  <TableRow>
+    <TableCell colSpan={6} style={{textAlign: 'center'}}>
+      There are no assets to display
+    </TableCell>
+  </TableRow>
+);
+
+const mapStateToProps = ({ assets: { summaries, isLoading } }) => ({
+  summaries, isLoading
+});
+
+export default connect(mapStateToProps)(UnconnectedAssetTableBody);

--- a/src/components/AssetTableBody.test.js
+++ b/src/components/AssetTableBody.test.js
@@ -6,27 +6,27 @@ import React from 'react';
 jest.mock('./AssetListItem', () => () => <div />);
 
 import AssetListItem from './AssetListItem';
-import { UnconnectedAssetTable as AssetTable, ZeroAssetsRow } from './AssetTable';
+import { UnconnectedAssetTableBody as AssetTableBody, ZeroAssetsRow } from './AssetTableBody';
 import { render } from '../testutils';
 
-test('AssetTable contains no AssetListItem if no assets', () => {
-  const instance = render(<AssetTable assetSummaries={[]} />);
+test('AssetTableBody contains no AssetListItem if no assets', () => {
+  const instance = render(<AssetTableBody summaries={[]} />);
   expect(instance.findAllByType(AssetListItem)).toEqual([]);
 });
 
-test('AssetTable contains a ZeroAssetsRow if no assets', () => {
-  const instance = render(<AssetTable assetSummaries={[]} />);
+test('AssetTableBody contains a ZeroAssetsRow if no assets', () => {
+  const instance = render(<AssetTableBody summaries={[]} />);
   instance.findByType(ZeroAssetsRow);
 });
 
-test('AssetTable does not contain a ZeroAssetsRow if no assets but we are loading', () => {
-  const instance = render(<AssetTable isLoadingAssets={true} assetSummaries={[]} />);
+test('AssetTableBody does not contain a ZeroAssetsRow if no assets but we are loading', () => {
+  const instance = render(<AssetTableBody isLoading={true} summaries={[]} />);
   expect(instance.findAllByType(ZeroAssetsRow)).toEqual([]);
 });
 
-test('AssetTable contains an AssetListItem for each asset summary', () => {
+test('AssetTableBody contains an AssetListItem for each asset summary', () => {
   const summaries = [{url: 'a'}, {url: 'b'}];
-  const instance = render(<AssetTable assetSummaries={summaries} />);
+  const instance = render(<AssetTableBody summaries={summaries} />);
   const items = instance.findAllByType(AssetListItem);
   expect(items).toHaveLength(2);
   summaries.forEach((asset, index) => {

--- a/src/components/AssetTableHeader.js
+++ b/src/components/AssetTableHeader.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { getAssets, Direction } from '../redux/actions/assetRegisterApi';
+import { TableRow, TableCell, TableSortLabel, TableHead } from 'material-ui/Table';
+
+// A map from sort directions to values for the "direction" prop of TableSortLabel.
+const directionDescriptions = new Map([
+  [Direction.ascending, 'asc'], [Direction.descending, 'desc']
+]);
+
+// Given the current assets list query and the field name corresponding to a column, return the
+// query which should be run if that column's header is clicked.
+const getNextQuery = (query, field) => {
+  const { sort: { field: sortField, direction } } = query;
+  if(sortField !== field) {
+    return {...query, sort: { field, direction: Direction.ascending } };
+  } else {
+    // the current query sorts by this field, change the direction
+    const newDirection =
+        direction === Direction.ascending ? Direction.descending : Direction.ascending;
+    return {...query, sort: { field, direction: newDirection } };
+  }
+}
+
+/**
+ * A table heading cell which shows if the current asset list is sorted by a particular field and,
+ * if so, in which direction.
+ */
+const UnconnectedSortCell = ({ direction, active, label, nextQuery, getAssets }) => (
+  <TableCell sortDirection={active ? direction : false}>
+    <TableSortLabel onClick={() => getAssets(nextQuery)} active={active} direction={direction}>
+      {label}
+    </TableSortLabel>
+  </TableCell>
+);
+
+// IMPORTANT: Since SortCell makes use of animations via the CSS transition property, we need to
+// make sure to give the component as simple props as possible in order to maximise React's
+// likelihood of not re-creating the underlying DOM element but simply modifying its content.
+//
+// The list of props here were empirically determined to be "simple enough" to cause the nice
+// animation to show.
+//
+// This has the nice side-effect that the implementation of the AssetTableHeader component itself
+// is entirely stateless.
+const mapStateToProps = ({ assets: { query } }, { label, field }) => {
+  const { sort } = query;
+  const active = sort.field === field;
+  const direction = directionDescriptions.get(sort.direction);
+  return { direction, active, label, nextQuery: getNextQuery(query, field) };
+};
+
+const mapDispatchToProps = { getAssets };
+
+const SortCell = connect(mapStateToProps, mapDispatchToProps)(UnconnectedSortCell);
+
+SortCell.propTypes = {
+  field: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+};
+
+/**
+ * A component which provides the header row for the asset table. Heading titles can be used to
+ * change sort order.
+ *
+ */
+export const AssetTableHeader = () => (
+  <TableHead>
+    <TableRow>
+      <SortCell field='name' label='Name' />
+      <SortCell field='is_complete' label='Status' />
+      <SortCell field='department' label='Department' />
+      <SortCell field='private' label='Private' />
+      <SortCell field='updated_at' label='Last edited' />
+      <TableCell>&nbsp;</TableCell>
+    </TableRow>
+  </TableHead>
+);
+
+export default AssetTableHeader;

--- a/src/components/AssetTableHeader.js
+++ b/src/components/AssetTableHeader.js
@@ -11,7 +11,7 @@ const directionDescriptions = new Map([
 
 // Given the current assets list query and the field name corresponding to a column, return the
 // query which should be run if that column's header is clicked.
-const getNextQuery = (query, field) => {
+export const getNextQuery = (query, field) => {
   const { sort: { field: sortField, direction } } = query;
   if(sortField !== field) {
     return {...query, sort: { field, direction: Direction.ascending } };
@@ -53,7 +53,7 @@ const mapStateToProps = ({ assets: { query } }, { label, field }) => {
 
 const mapDispatchToProps = { getAssets };
 
-const SortCell = connect(mapStateToProps, mapDispatchToProps)(UnconnectedSortCell);
+export const SortCell = connect(mapStateToProps, mapDispatchToProps)(UnconnectedSortCell);
 
 SortCell.propTypes = {
   field: PropTypes.string.isRequired,

--- a/src/components/AssetTableHeader.test.js
+++ b/src/components/AssetTableHeader.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, createMockStore, DEFAULT_INITIAL_STATE } from '../testutils';
+import Table, { TableHead, TableRow, TableSortLabel } from 'material-ui/Table';
+import { Direction } from '../redux/actions/assetRegisterApi';
+import { SortCell, getNextQuery } from './AssetTableHeader';
+
+const wrap = sortCell => (
+  <Table><TableHead><TableRow>{ sortCell }</TableRow></TableHead></Table>
+);
+
+// Return initialise store with query replaced
+const storeWithQuery = query => {
+  query = { ...DEFAULT_INITIAL_STATE.assets.query, ...query };
+  const assets = { ...DEFAULT_INITIAL_STATE.assets, query };
+  const state = { ...DEFAULT_INITIAL_STATE, assets };
+  return createMockStore(state);
+};
+
+test('getNextQuery sorts descending if already sorting by field ascending', () => {
+  const prevQuery = { sort: { field: 'xx', direction: Direction.ascending } };
+  const nextQuery = getNextQuery(prevQuery, 'xx');
+  expect(nextQuery.sort.field).toBe('xx');
+  expect(nextQuery.sort.direction).toBe(Direction.descending);
+});
+
+test('getNextQuery sorts ascending if already sorting by field descending', () => {
+  const prevQuery = { sort: { field: 'xx', direction: Direction.descending } };
+  const nextQuery = getNextQuery(prevQuery, 'xx');
+  expect(nextQuery.sort.field).toBe('xx');
+  expect(nextQuery.sort.direction).toBe(Direction.ascending);
+});
+
+test('getNextQuery sorts ascending if not already sorting by field', () => {
+  const prevQuery = { sort: { field: 'xx', direction: Direction.descending } };
+  const nextQuery = getNextQuery(prevQuery, 'yy');
+  expect(nextQuery.sort.field).toBe('yy');
+  expect(nextQuery.sort.direction).toBe(Direction.ascending);
+});
+
+test('sort cell renders with initial state', () => {
+  const sortCell = render(wrap(<SortCell field='xx' label='yy' />)).findByType(SortCell);
+});
+
+test('sort cell renders inactive if not filtering by field', () => {
+  const store = storeWithQuery({ sort: { field: 'xx', direction: Direction.ascending } });
+  const sortCell = render(wrap(<SortCell field='zz' label='yy' />), { store }).findByType(SortCell);
+  expect(sortCell.findByType(TableSortLabel).props.active).toBe(false);
+});
+
+test('sort cell renders active if filtering by field', () => {
+  const store = storeWithQuery({ sort: { field: 'xx', direction: Direction.ascending } });
+  const sortCell = render(wrap(<SortCell field='xx' label='yy' />), { store }).findByType(SortCell);
+  expect(sortCell.findByType(TableSortLabel).props.active).toBe(true);
+});
+
+test('sort cell renders ascending sort direction', () => {
+  const store = storeWithQuery({ sort: { field: 'xx', direction: Direction.ascending } });
+  const sortCell = render(wrap(<SortCell field='xx' label='yy' />), { store }).findByType(SortCell);
+  expect(sortCell.findByType(TableSortLabel).props.direction).toBe('asc');
+});
+
+test('sort cell renders descending sort direction', () => {
+  const store = storeWithQuery({ sort: { field: 'xx', direction: Direction.descending } });
+  const sortCell = render(wrap(<SortCell field='xx' label='yy' />), { store }).findByType(SortCell);
+  expect(sortCell.findByType(TableSortLabel).props.direction).toBe('desc');
+});

--- a/src/containers/AssetForm.test.js
+++ b/src/containers/AssetForm.test.js
@@ -46,7 +46,7 @@ fetch_mock.get(ASSET_FIXTURE_URL, ASSET_FIXTURE);
 
 // Required because asset form redirects to the index when the form has been saved and the index
 // will fetch the asset list.
-fetch_mock.get('http://localhost:8000/assets/', {
+fetch_mock.get('http://localhost:8000/assets/?ordering=-updated_at', {
   next: null, previous: null, results: [ ASSET_FIXTURE ],
 });
 

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -15,6 +15,11 @@ const TITLES = {
   '/assets/all': 'Assets: All',
 };
 
+// Default query to use if none has previously been set by the user.
+export const DEFAULT_QUERY = {
+  sort: { field: 'updated_at', direction: Direction.descending },
+};
+
 class AssetList extends Component {
   componentDidMount() {
     const { getAssets, lastAssetListUrl } = this.props;
@@ -22,7 +27,15 @@ class AssetList extends Component {
     // Fetch an asset list if one has not already been fetched. We detect a fetch by looking at the
     // "url" property in the assets state which is exposed as the "lastAssetListUrl" prop.
     if(!lastAssetListUrl) {
-      getAssets({ sort: { field: 'updated_at', direction: Direction.descending } });
+      // If there is currently a sort query set by the user, use that otherwise update the query
+      // with a default sort.
+      const { query } = this.props;
+      const { sort: { field } } = query;
+      if(field !== null) {
+        getAssets(query);
+      } else {
+        getAssets({ ...query, ...DEFAULT_QUERY });
+      }
     }
   }
 
@@ -47,9 +60,12 @@ class AssetList extends Component {
 AssetList.propTypes = {
   match: PropTypes.object.isRequired,
   lastAssetListUrl: PropTypes.string,
+  query: PropTypes.object.isRequired,
 };
 
-const mapStateToProps = ({ assets: { url: lastAssetListUrl } }) => ({ lastAssetListUrl });
+const mapStateToProps = ({ assets: { url: lastAssetListUrl, query } }) => (
+  { lastAssetListUrl, query }
+);
 
 const mapDispatchToProps = { getAssets };
 

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -1,10 +1,12 @@
-import React from 'react'; // used implicitly by JSX
+import React, { Component } from 'react'; // used implicitly by JSX
 import PropTypes from 'prop-types';
 import AssetListHeader from '../components/AssetListHeader';
 import AssetTable from '../components/AssetTable';
 import Page from '../containers/Page';
 import GetMoreAssets from '../components/GetMoreAssets';
 import { withRouter } from 'react-router'
+import { connect } from 'react-redux';
+import { getAssets, Direction } from '../redux/actions/assetRegisterApi';
 
 import '../style/App.css';
 
@@ -13,22 +15,42 @@ const TITLES = {
   '/assets/all': 'Assets: All',
 };
 
-const AssetList = ({ match }) => (
-  <Page>
-    <AssetListHeader title={TITLES[match.url]} />
+class AssetList extends Component {
+  componentDidMount() {
+    const { getAssets, lastAssetListUrl } = this.props;
 
-    {/* Table of currently loaded assets. */}
-    <AssetTable />
+    // Fetch an asset list if one has not already been fetched. We detect a fetch by looking at the
+    // "url" property in the assets state which is exposed as the "lastAssetListUrl" prop.
+    if(!lastAssetListUrl) {
+      getAssets({ sort: { field: 'updated_at', direction: Direction.descending } });
+    }
+  }
 
-    <div style={{textAlign: 'center'}}>
-      {/* When this component becomes visible more assets are loaded to populate the table. */}
-      <GetMoreAssets />
-    </div>
-  </Page>
-);
+  render() {
+    const { match } = this.props;
+    return (
+      <Page>
+        <AssetListHeader title={TITLES[match.url]} />
+
+        {/* Table of currently loaded assets. */}
+        <AssetTable />
+
+        <div style={{textAlign: 'center'}}>
+          {/* When this component becomes visible more assets are loaded to populate the table. */}
+          <GetMoreAssets />
+        </div>
+      </Page>
+    );
+  }
+};
 
 AssetList.propTypes = {
   match: PropTypes.object.isRequired,
+  lastAssetListUrl: PropTypes.string,
 };
 
-export default withRouter(AssetList);
+const mapStateToProps = ({ assets: { url: lastAssetListUrl } }) => ({ lastAssetListUrl });
+
+const mapDispatchToProps = { getAssets };
+
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(AssetList));

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -22,11 +22,12 @@ export const DEFAULT_QUERY = {
 
 class AssetList extends Component {
   componentDidMount() {
-    const { getAssets, lastAssetListUrl } = this.props;
+    const { getAssets, fetchedAt } = this.props;
 
-    // Fetch an asset list if one has not already been fetched. We detect a fetch by looking at the
-    // "url" property in the assets state which is exposed as the "lastAssetListUrl" prop.
-    if(!lastAssetListUrl) {
+    // Fetch an asset list if one has not already been fetched. We detect an existing fetch by
+    // looking at the "fetchedAt" value on the asset list which should be non-NULL if a fetch
+    // happened.
+    if(!fetchedAt) {
       // If there is currently a sort query set by the user, use that otherwise update the query
       // with a default sort.
       const { query } = this.props;
@@ -59,12 +60,12 @@ class AssetList extends Component {
 
 AssetList.propTypes = {
   match: PropTypes.object.isRequired,
-  lastAssetListUrl: PropTypes.string,
+  fetchedAt: PropTypes.object,
   query: PropTypes.object.isRequired,
 };
 
-const mapStateToProps = ({ assets: { url: lastAssetListUrl, query } }) => (
-  { lastAssetListUrl, query }
+const mapStateToProps = ({ assets: { fetchedAt, query } }) => (
+  { fetchedAt, query }
 );
 
 const mapDispatchToProps = { getAssets };

--- a/src/containers/AssetList.test.js
+++ b/src/containers/AssetList.test.js
@@ -1,0 +1,68 @@
+// mock any components which are troublesome in our test suite
+import '../test/mocks';
+
+// mock the assetRegisterApi actions module
+jest.mock('../redux/actions/assetRegisterApi', () => {
+  const original = require.requireActual('../redux/actions/assetRegisterApi');
+  return {
+    ...original,
+    getAssets: jest.fn(() => ({ type: 'mock-get-assets-action' })),
+  };
+});
+
+import React from 'react';
+import { render, createMockStore, DEFAULT_INITIAL_STATE } from '../testutils';
+import AppRoutes from './AppRoutes';
+import { DEFAULT_QUERY } from './AssetList';
+import { getAssets, Direction } from '../redux/actions/assetRegisterApi';
+
+beforeEach(() => {
+  getAssets.mockClear();
+});
+
+// NB: We need to do the full AppRoutes dance here since the match url is used to key the app bar
+// title and that must be defined by the AppBar's prop types. Should the AppBar title logic be
+// re-worked, we can move to testing the AssetList component directly.
+
+test('AssetList can render', () => {
+  const testInstance = render(<AppRoutes />, { url: '/assets/all' });
+});
+
+test('AssetList sends a default query if none is set', () => {
+  const store = createMockStore(DEFAULT_INITIAL_STATE);
+  const testInstance = render(<AppRoutes />, { store, url: '/assets/all' });
+
+  // getAssets was called once
+  expect(getAssets.mock.calls).toHaveLength(1);
+
+  // get single argument to getAssets
+  const [ [ query ] ] = getAssets.mock.calls;
+
+  // check query matches default query
+  Object.getOwnPropertyNames(DEFAULT_QUERY).forEach(name => {
+    expect(query[name]).toEqual(DEFAULT_QUERY[name]);
+  });
+});
+
+test('AssetList respects the current query', () => {
+  const initialState = { ...DEFAULT_INITIAL_STATE };
+  const initialQuery = {
+    ...initialState.assets.query,
+    sort: { field: 'name', direction: Direction.descending }
+  };
+  initialState.assets = { ...initialState.assets, query: initialQuery };
+
+  const store = createMockStore(initialState);
+  const testInstance = render(<AppRoutes />, { store, url: '/assets/all' });
+
+  // getAssets was called once
+  expect(getAssets.mock.calls).toHaveLength(1);
+
+  // get single argument to getAssets
+  const [ [ query ] ] = getAssets.mock.calls;
+
+  // check query matches expected query
+  Object.getOwnPropertyNames(initialQuery).forEach(name => {
+    expect(query[name]).toEqual(initialQuery[name]);
+  });
+});

--- a/src/redux/actions/assetRegisterApi.js
+++ b/src/redux/actions/assetRegisterApi.js
@@ -61,10 +61,12 @@ export const Direction = Object.freeze({
  *   are looked at. Other properties are ignored.
  *
  */
-export const getAssets = ({
-  sort: { field: sortBy = 'created_at', direction = Direction.descending } = { }, search, filter
-} = {}) => {
-  // Build a query string from the options passed to this action.
+export const getAssets = (unsanitisedQuery = {}) => {
+  // Unpick values from the function input to sanitise input.
+  let {
+    search, filter,
+    sort: { field: sortBy = 'created_at', direction = Direction.descending } = { }
+  } = unsanitisedQuery;
 
   // Array of [key, value] pairs which are built into the query string.
   const queryParts = [];

--- a/src/redux/actions/assetRegisterApi.js
+++ b/src/redux/actions/assetRegisterApi.js
@@ -1,4 +1,5 @@
 import { RSAA } from 'redux-api-middleware';
+import { ENDPOINT_ASSETS } from '../../config';
 
 export const ASSETS_LIST_REQUEST = Symbol('ASSETS_LIST_REQUEST');
 export const ASSETS_LIST_SUCCESS = Symbol('ASSETS_LIST_SUCCESS');
@@ -11,6 +12,104 @@ export const ASSETS_DELETE_FAILURE = Symbol('ASSETS_DELETE_FAILURE');
 export const ASSET_GET_REQUEST = Symbol('ASSET_GET_REQUEST');
 export const ASSET_GET_SUCCESS = Symbol('ASSET_GET_SUCCESS');
 export const ASSET_GET_FAILURE = Symbol('ASSET_GET_FAILURE');
+
+// Shared fields between FILTER_FIELDS and SORT_FIELDS.
+const COMMON_FIELDS = [
+  'id', 'name', 'department', 'purpose', 'owner', 'private', 'research', 'personal_data',
+  'data_subject', 'data_category', 'recipients_category', 'recipients_outside_eea', 'retention',
+  'risk_type', 'storage_location', 'storage_format', 'paper_storage_security', 'is_complete',
+  'digital_storage_security',
+];
+
+// Set of fields which can be used as a filter
+export const FILTER_FIELDS = new Set(COMMON_FIELDS);
+
+// Set of fields which can be used for sorting
+export const SORT_FIELDS = new Set([...COMMON_FIELDS, 'created_at', 'updated_at']);
+
+export const Direction = Object.freeze({
+  ascending: Symbol('ascending'), descending: Symbol('descending')
+});
+
+/**
+ * Fetch a new set of assets. Optionally passed an object containing the following properties:
+ *
+ * sort: (optional) object with following structure:
+ *
+ *  { field, direction }
+ *
+ *    field: (optional) String giving the field name which should be used for ordering the returned
+ *      results. By default the results are ordered by created_at. Must be one of the strings in
+ *      SORT_FIELDS. If sortBy is not in SORT_FIELDS, this is ignored. Default: created_at.
+ *
+ *    direction: (optional) One of Direction.ascending or Direction.descending depending on what
+ *      order the sorted results should be returned in. Invalid values are ignored. Default:
+ *      Direction.descending.
+ *
+ * search: (optional) String which should be matched against all asset fields.
+ *
+ * filter: (optional) Object whose properties specify filters. Only the properties in FILTER_FIELDS
+ *   are looked at. Other properties are ignored.
+ *
+ */
+export const getAssets = ({
+  sort: { field: sortBy = 'created_at', direction = Direction.descending } = { }, search, filter
+} = {}) => {
+  // Build a query string from the options passed to this action.
+
+  // Array of [key, value] pairs which are built into the query string.
+  const queryParts = [];
+
+  // Object representing this query in the state.
+  const query = { sort: { field: null, direction: null }, filter: { }, search: null };
+
+  // Add in search query
+  if(search) { queryParts.push(['search', search]); query.search = search; }
+
+  // If direction is not one of the expected values, it defaults to descending
+  switch(direction) {
+    case Direction.ascending:
+    case Direction.descending:
+      break;
+    default:
+      direction = Direction.descending;
+  }
+
+  // Add in sort by field
+  if(SORT_FIELDS.has(sortBy)) {
+    query.sort = { field: sortBy, direction: direction };
+    queryParts.push(['ordering', ((direction === Direction.descending) ? '-' : '') + sortBy]);
+  }
+
+  // Add in filter fields.
+  if(filter) {
+    Object.getOwnPropertyNames(filter)
+      .filter(propName => FILTER_FIELDS.has(propName))
+      .forEach(propName => {
+        queryParts.push([propName, filter[propName]]);
+        query.filter[propName] = filter[propName];
+      });
+  }
+
+  // Build the URL
+  const url = ENDPOINT_ASSETS + (
+    (queryParts.length > 0)
+    ? ('?' + queryParts.map(([key, value]) => key + '=' + encodeURIComponent(value)).join('&'))
+    : ''
+  );
+
+  return {
+    [RSAA]: {
+      endpoint: url,
+      method: 'GET',
+      types: [
+        { type: ASSETS_LIST_REQUEST, meta: { url, query } },
+        { type: ASSETS_LIST_SUCCESS, meta: { url, query } },
+        { type: ASSETS_LIST_FAILURE, meta: { url, query } },
+      ],
+    }
+  };
+};
 
 /**
  * Request more assets from the API. If URL corresponds to the "next" or "previous" URLs, the list

--- a/src/redux/actions/assetRegisterApi.js
+++ b/src/redux/actions/assetRegisterApi.js
@@ -4,6 +4,7 @@ import { ENDPOINT_ASSETS } from '../../config';
 export const ASSETS_LIST_REQUEST = Symbol('ASSETS_LIST_REQUEST');
 export const ASSETS_LIST_SUCCESS = Symbol('ASSETS_LIST_SUCCESS');
 export const ASSETS_LIST_FAILURE = Symbol('ASSETS_LIST_FAILURE');
+export const ASSETS_LIST_RESET = Symbol('ASSETS_LIST_RESET');
 
 export const ASSETS_DELETE_SUCCESS = Symbol('ASSETS_DELETE_SUCCESS');
 export const ASSETS_DELETE_REQUEST = Symbol('ASSETS_DELETE_REQUEST');
@@ -133,6 +134,17 @@ export const getMoreAssets = (url) => ({
       { type: ASSETS_LIST_FAILURE, meta: { url } },
     ],
   }
+});
+
+/**
+ * Reset the asset list to the initial "unfetched" state.
+ *
+ * The current query state is not changed. The effect of this action is performed whenever an asset
+ * is modified or created via putAsset or postAsset so there's no need to fire this action if
+ * modifying assets.
+ */
+export const resetAssets = () => ({
+  type: ASSETS_LIST_RESET,
 });
 
 /**

--- a/src/redux/actions/assetRegisterApi.test.js
+++ b/src/redux/actions/assetRegisterApi.test.js
@@ -1,0 +1,77 @@
+import { RSAA } from 'redux-api-middleware';
+import { getAssets, Direction } from './assetRegisterApi';
+import { ENDPOINT_ASSETS } from '../../config';
+
+// utility function which takes a URL, splits the query string and returns the base URL and query
+// string split at '&' characters into an array of 'xxx=yyy' strings. This is not a full URL parser
+// but is good enough for our needs. Returns an object of the form { baseUrl, queryItems }. If
+// there is no query string, queryItems is null.
+const splitUrl = url => {
+  const [ baseUrl, queryString ] = url.split('?', 2);
+  const queryItems = (queryString !== undefined) ? queryString.split('&') : null;
+  return { baseUrl, queryItems };
+};
+
+// call getAssets() with the passed arguments, calls splitUrl, checks the baseUrl is the assets
+// endpoint and returns the queryItems from splitUrl()
+const getAssetsAndParse = (...args) => {
+  const { [RSAA]: { endpoint = '' } } = getAssets(...args);
+  const { baseUrl, queryItems } = splitUrl(endpoint);
+  expect(baseUrl).toBe(ENDPOINT_ASSETS);
+  return queryItems;
+};
+
+test('simple call to getAssets just returns assets endpoint', () => {
+  const queryItems = getAssetsAndParse();
+  expect(queryItems).toHaveLength(1);
+  expect(queryItems).toContain('ordering=-created_at');
+});
+
+test('adding a search adds an appropriately encoded query parameter', () => {
+  const queryItems = getAssetsAndParse({ search: 'one two' });
+  expect(queryItems).toHaveLength(2);
+  expect(queryItems).toContain('ordering=-created_at');
+  expect(queryItems).toContain('search=one%20two');
+});
+
+test('can add sort field', () => {
+  const queryItems = getAssetsAndParse({ sort: { field: 'name' } });
+  expect(queryItems).toEqual(['ordering=-name']);
+});
+
+test('can add ascending sort field', () => {
+  const queryItems = getAssetsAndParse({ sort: { field: 'name', direction: Direction.ascending } });
+  expect(queryItems).toEqual(['ordering=name']);
+});
+
+test('can add descending sort field', () => {
+  const queryItems = getAssetsAndParse({ sort: { field: 'name', direction: Direction.descending } });
+  expect(queryItems).toEqual(['ordering=-name']);
+});
+
+test('invalid directions are ignored', () => {
+  const queryItems = getAssetsAndParse({ sort: { field: 'name', direction: 'RANDOM' } });
+  expect(queryItems).toEqual(['ordering=-name']);
+});
+
+test('Can filter by multiple fields with invalid ones being ignored', () => {
+  const queryItems = getAssetsAndParse({
+    filter: { name: 'xxx', department: 'yyy', badField: 'zzz', ordering: 'aaa', search: 'bbb' }
+  });
+  expect(queryItems).toHaveLength(3);
+  expect(queryItems).toContain('ordering=-created_at');
+  expect(queryItems).toContain('department=yyy');
+  expect(queryItems).toContain('name=xxx');
+});
+
+test('sort, search and filter can be combined together', () => {
+  const queryItems = getAssetsAndParse({
+    sort: { field: 'name', direction: Direction.descending }, search: 'one two',
+    filter: { name: 'a b c', department: 'd e f', no_such_field: 'zzz' }
+  });
+  expect(queryItems).toHaveLength(4);
+  expect(queryItems).toContain('search=one%20two');
+  expect(queryItems).toContain('ordering=-name');
+  expect(queryItems).toContain('department=d%20e%20f');
+  expect(queryItems).toContain('name=a%20b%20c');
+});

--- a/src/redux/reducers/assetRegisterApi.test.js
+++ b/src/redux/reducers/assetRegisterApi.test.js
@@ -1,5 +1,25 @@
 import reducer, { initialState } from './assetRegisterApi';
-import { ASSETS_LIST_SUCCESS, ASSETS_DELETE_SUCCESS } from '../actions/assetRegisterApi';
+import {
+  ASSETS_LIST_SUCCESS, ASSETS_DELETE_SUCCESS,
+  ASSET_PUT_SUCCESS, ASSET_POST_SUCCESS,
+  resetAssets,
+} from '../actions/assetRegisterApi';
+
+// A redux store state which contains some fetched assets
+let stateWithAssets;
+
+beforeEach(() => {
+  stateWithAssets = {
+    ...initialState,
+    url: 'x', next: 'y', previous: 'z', fetchedAt: new Date(),
+    summaries: [{url: 'x'}, {url: 'y'}, {url: 'z'}],
+    assetsByUrl: new Map([
+      ['x', {url: 'x', id: 'xxx', name: 'foo'}],
+      ['y', {url: 'y', id: 'yyy', name: 'bar'}],
+      ['z', {url: 'z', id: 'zzz', name: 'buzz'}],
+    ]),
+  };
+});
 
 test('asset list response updates replaces list if url does not match next or prev', () => {
   const previousState = { ...initialState, summaries: [{url: 'x'}, {url: 'y'}] };
@@ -18,4 +38,43 @@ test('asset delete response deletes asset', () => {
   const action = { type: ASSETS_DELETE_SUCCESS, meta: { url: 'y' } };
   const nextState = reducer(previousState, action);
   expect(nextState.summaries).toEqual([{url: 'x'}, {url: 'z'}]);
+});
+
+test('PUT asset resets summary state', () => {
+  const action = { type: ASSET_PUT_SUCCESS, payload: { url: 'y', id: 'y' }, meta: { url: 'y' } };
+  const nextState = reducer(stateWithAssets, action);
+  expect(nextState.url).toBeNull();
+  expect(nextState.next).toBeNull();
+  expect(nextState.previous).toBeNull();
+  expect(nextState.fetchedAt).toBeNull();
+});
+
+test('POST asset resets summary state', () => {
+  const action = { type: ASSET_POST_SUCCESS, payload: { url: 'y', id: 'y' }, meta: { url: 'y' } };
+  const nextState = reducer(stateWithAssets, action);
+  expect(nextState.url).toBeNull();
+  expect(nextState.next).toBeNull();
+  expect(nextState.previous).toBeNull();
+  expect(nextState.fetchedAt).toBeNull();
+});
+
+test('PUT asset updates assetsByUrl', () => {
+  const action = { type: ASSET_PUT_SUCCESS, payload: { url: 'a', id: 'y' }, meta: { url: 'a' } };
+  const nextState = reducer(stateWithAssets, action);
+  expect(nextState.assetsByUrl.get('a')).toBeDefined();
+});
+
+test('POST asset updates assetsByUrl', () => {
+  const action = { type: ASSET_POST_SUCCESS, payload: { url: 'a', id: 'y' }, meta: { url: 'a' } };
+  const nextState = reducer(stateWithAssets, action);
+  expect(nextState.assetsByUrl.get('a')).toBeDefined();
+});
+
+test('Explicit reset of summary state', () => {
+  const action = resetAssets();
+  const nextState = reducer(stateWithAssets, action);
+  expect(nextState.url).toBeNull();
+  expect(nextState.next).toBeNull();
+  expect(nextState.previous).toBeNull();
+  expect(nextState.fetchedAt).toBeNull();
 });


### PR DESCRIPTION
Add sorting to the asset list. Filtering would also be possible but there is no UI design for it yet so I've left it for another story. This is done with two commits:

e32351b adds a new action, getAssets, which fetches a new list of assets from the API with a query specifying search, sorting and filtering. When the request succeeds, the redux state is updated to record the query so that UI components can react.

78cdb60 adds some UI components which react to this change by re-factoring the AssetTable body and header into two components and making use of the new TableSortLabel component from MUI v1 to render a nice header.

**Update:** After merging current master, I found that the asset list was not correctly refreshed after asset creation. a94f955 fixes that and 8ec87da ensures that the user does not lose their current sort settings by editing an asset. Finally, e792424 corrects the logic used to detect an asset list fetch by examining the assets.fetchedAt value in the redux store state.

Closes #21