### PR TITLE
add help content for static page

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -15,12 +15,8 @@ const Sidebar = () => (
       <li><Link to="/assets/dept">My department</Link></li>
       <li><Link to="/assets/all">All</Link></li>
       <hr/>
-      <li><Link to="/static/what-is-asset">What is an information asset?</Link></li>
-      <li><Link to="/static/what-i-do">What do I need to do?</Link></li>
+      <li><Link to="/help">Help</Link></li>
       <hr/>
-      <li><Link to="/static/feedback">Feedback</Link></li>
-      <li><Link to="/static/contact">Contact</Link></li>
-      <li><Link to="/static/tcs">Terms & Conditions</Link></li>
       <li><LogoutLink>Sign out</LogoutLink></li>
     </ul>
   </Drawer>

--- a/src/containers/AppRoutes.js
+++ b/src/containers/AppRoutes.js
@@ -14,7 +14,6 @@ import NotFoundPage from './NotFoundPage';
  */
 const AppRoutes = () => (
   <Switch>
-    <LoginRequiredRoute path="/static/:page" exact component={Static}/>
     <LoginRequiredRoute path="/assets/:filter" exact component={AssetList}/>
     <LoginRequiredRoute
        path="/asset/create" exact
@@ -25,6 +24,9 @@ const AppRoutes = () => (
          url={config.ENDPOINT_ASSETS + routeProps.match.params.assetId + '/'}
          {...routeProps} />}
     />
+
+    <LoginRequiredRoute path="/help" exact component={() => <Static page='help' />}/>
+
     <Route path="/oauth2-callback" exact component={() => <div />} />
     <Redirect from='/' exact to='/assets/dept' />
 

--- a/src/containers/AppRoutes.test.js
+++ b/src/containers/AppRoutes.test.js
@@ -15,34 +15,10 @@ const appBarTitle = testInstance => (
  * Simple unit test which assert that routes generate pages with the correct titles.
  */
 
-test('can render /static/what-is-asset', () => {
-  const testInstance = render(<AppRoutes/>, {url: '/static/what-is-asset'});
+test('can render /help', () => {
+  const testInstance = render(<AppRoutes/>, {url: '/help'});
 
-  expect(appBarTitle(testInstance)).toBe('What is an information asset?')
-});
-
-test('can render /static/what-i-do', () => {
-  const testInstance = render(<AppRoutes/>, {url: '/static/what-i-do'});
-
-  expect(appBarTitle(testInstance)).toBe('What do I need to do?')
-});
-
-test('can render /static/feedback', () => {
-  const testInstance = render(<AppRoutes/>, {url: '/static/feedback'});
-
-  expect(appBarTitle(testInstance)).toBe('Feedback')
-});
-
-test('can render /static/contact', () => {
-  const testInstance = render(<AppRoutes/>, {url: '/static/contact'});
-
-  expect(appBarTitle(testInstance)).toBe('Contact')
-});
-
-test('can render /static/tcs', () => {
-  const testInstance = render(<AppRoutes/>, {url: '/static/tcs'});
-
-  expect(appBarTitle(testInstance)).toBe('Terms & Conditions')
+  expect(appBarTitle(testInstance)).toBe('Help')
 });
 
 test('can render /assets/dept', () => {

--- a/src/containers/Static.js
+++ b/src/containers/Static.js
@@ -1,15 +1,21 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Page from '../containers/Page';
 import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
+import Paper from 'material-ui/Paper';
+import Grid from 'material-ui/Grid';
+import { withStyles } from 'material-ui/styles';
 
-const TITLES = {
-  '/static/what-is-asset': 'What is an information asset?',
-  '/static/what-i-do': 'What do I need to do?',
-  '/static/feedback': 'Feedback',
-  '/static/contact': 'Contact',
-  '/static/tcs': 'Terms & Conditions',
+// Import static page contents
+import help from '../static/help';
+
+// Initialise object mapping page names to their content.
+const pages = { help };
+
+const styles = {
+  paper: { padding: '16px 24px' },
 };
 
 /*
@@ -25,18 +31,32 @@ const StaticHeader = ({ title }) => (
   </AppBar>
 );
 
-/*
-  Renders the IAR app's static pages.
+/**
+ * Renders the IAR app's static pages.
+ *
+ * The page prop must be a string with corresponding content object in pages.
  */
-const Static = ({ match }) => (
-  <Page>
-    <div>
-      <StaticHeader title={ TITLES[match.url] } />
+const Static = ({ page, classes }) => {
+  const { title, content } = pages[page];
+  return (
+    <Page>
       <div>
-        <h1>Copy for "{ TITLES[match.url] }"</h1>
+        <StaticHeader title={title} />
+        <Paper className={classes.paper}>
+          <Grid container justify='center'>
+            <Grid item xs={12} sm={10} md={8} lg={6} >
+              <Typography>{ content }</Typography>
+            </Grid>
+          </Grid>
+        </Paper>
       </div>
-    </div>
-  </Page>
-);
+    </Page>
+  );
+}
 
-export default Static;
+Static.propTypes = {
+  page: PropTypes.string.isRequired,
+  classes: PropTypes.object.isRequired,
+}
+
+export default withStyles(styles)(Static);

--- a/src/static/help.js
+++ b/src/static/help.js
@@ -1,0 +1,155 @@
+/**
+ * Static content for the "help" page.
+ */
+import React from 'react';
+
+export const title = 'Help';
+
+export const content = (<div>
+
+<h1>The information asset</h1>
+
+<p>An information asset is a set of information that is held by, and is valuable to, the University of
+Cambridge, whether electronically and/or in hard copy.</p>
+
+<p>This may be a:</p>
+
+<ul>
+  <li>staff database</li>
+  <li>series of paper student records</li>
+  <li>collection of teaching materials</li>
+  <li>research dataset</li>
+</ul>
+
+<p>In this context, ‘the University’ means the Schools, Faculties, Departments, Non-School
+institutions, Research Centres / Units and UAS Divisions.</p>
+
+<p>It does not include the Colleges or information assets used solely by students.</p>
+
+<h1>The information asset register</h1>
+
+<p>If we know and fully understand what information we hold we can we protect it and use it to its
+potential.</p>
+
+<p>The information asset register (IAR) is a way to record headline information about the
+University of Cambridge's most important information assets, especially those that contain personal
+data.</p>
+
+<p>In addition, collecting this headline information meets the mandatory record-keeping
+requirements of the EU General Data Protection Regulation (GDPR), which becomes law on 25 May
+2018.</p>
+
+<h1>Information assets that should be included in the information asset register</h1>
+
+<p>We want to capture headline information about the most important information assets, especially
+those that:</p>
+
+<ul>
+  <li>contain <a href="#personal-data">personal data</a>, or</li>
+  <li>are crucial in enabling the University’s teaching, research and supporting administration,
+  and meeting its legal requirements (for example, in relation to financial record-keeping) (link
+    to other data below).</li>
+</ul>
+
+<h1><a id="personal-data">Personal data</a></h1>
+
+<p>Personal data means any information about a living identifiable individual.</p>
+
+<p>It isn’t limited to what might be considered ‘private’ or ‘confidential’ information about
+people. For example, a student’s name and email address are their personal data, as are their
+disability and ethnicity status.</p>
+
+<p>Examples of information assets that contain personal data are:</p>
+
+<ul>
+<li>departmental staff, student or alumni records</li>
+<li>case files relating to users of a staff/student service</li>
+<li>submitted work, exam scripts and other exam records where candidates are identifiable</li>
+<li>departmental committee records</li>
+<li>departmental health and safety records about individual staff</li>
+<li>complaint files</li>
+<li>the master copy of a research dataset with identifiable participants</li>
+</ul>
+
+<h1>Other data</h1>
+
+<p>Examples of important information assets that are unlikely to contain personal data but that
+should be included in the register are:</p>
+
+<ul>
+<li>a collection of teaching materials (lecture handouts, etc)</li>
+<li>the master copy of a research dataset with no identifiable participants</li>
+<li>financial reports and papers</li>
+<li>teaching quality assurance records</li>
+<li>anonymised results of, and reports about, surveys or initiatives</li>
+</ul>
+
+<h1>Examples</h1>
+
+<h2>Clinical Medicine</h2>
+
+<h2>Biological Science</h2>
+
+<h2>Physical Science</h2>
+
+<h2>Technology</h2>
+
+<h2>Arts and Humanities</h2>
+
+<h2>Humanities and Social Science</h2>
+
+<h1>Information that shouldn’t be considered an information asset</h1>
+
+<p>A system or application that collects, manages or stores information is not an information
+asset, but the information contained within it is.</p>
+
+<p>It is unlikely that the entirety of the content in a records management system can be treated as
+a single information asset as the content is likely to cover a diverse range of unrelated topics,
+each requiring different maintenance and management.</p>
+
+<p>Depending on the content in the system, records may be grouped into similar types and considered
+as a number of separate information assets.</p>
+
+<p>‘Unofficial’ information (such as personal correspondence) shouldn’t be considered an
+information asset, despite sometimes being captured on official organisational systems (for
+example, email systems).</p>
+
+<h1>Identifying An Information Asset</h1>
+
+<p>When thinking about what is an information asset ask the following questions:</p>
+
+<ol>
+  <li>Does the information have a value to the organisation? i.e.
+    <ul>
+      <li>How useful is it? </li>
+      <li>Will it cost money to reacquire? </li>
+      <li>
+        Would there be legal, reputational or financial repercussions if you couldn’t produce it
+        on request?
+      </li>
+      <li>
+        Would it have an effect on operational efficiency if you could not access it? Would there
+        be consequences for not having it?
+      </li>
+    </ul>
+  </li>
+
+  <li>
+    Is there a risk associated with the information?  Is there a risk of losing it? A risk that it
+    is not accurate? A risk that someone may tamper with it? A risk arising from inappropriate
+    disclosure?
+  </li>
+
+  <li>
+    Does the group of information have a specific content? i.e. Do you understand what it is and
+    what it does? Does it include all the context associated with the information?
+  </li>
+
+  <li>
+    Does the information have a manageable lifecycle? i.e. Were all the components created for a
+    common purpose? Will they be disposed of in the same way and according to the same rules?
+  </li>
+</ol>
+</div>);
+
+export default { title, content };


### PR DESCRIPTION
Since the re-design there is now only one static page. (And possibly
"Feedback".) Lift the content from the document cited in #11 and add
some basic styling for the page.

Static page content and titles are now defined in ES6 modules under
src/static for convenience of editing. The Static component is re-worked
to accept a page name corresponding to the module name under src/static.

Update the sidebar to link to the only static page we currently have.

Closes #11