### PR TITLE
Change button colour in headers

### DIFF
--- a/src/components/AssetFormHeader.js
+++ b/src/components/AssetFormHeader.js
@@ -7,9 +7,11 @@ import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
 
-const styles = {
+const styles = theme => ({
   flex: { flex: 1 },
-};
+  cancelButton: { color: theme.customColors.white },
+  saveButton: { background: theme.customColors.white }
+});
 
 /*
   Renders the app bar of the form for the creation/editing of an Asset.
@@ -21,10 +23,10 @@ const AssetFormHeader = ({ title, onClick, classes }) => (
         { title }
       </Typography>
       <Link className='App-raised-button-link' to="/">
-        <Button variant="raised" color='primary'>Cancel</Button>
+        <Button className={classes.cancelButton} color='primary'>Cancel</Button>
       </Link>
       &nbsp;
-      <Button variant="raised" onClick={onClick}>Save</Button>
+      <Button className={classes.saveButton} variant="raised" onClick={onClick}>Save</Button>
     </Toolbar>
   </AppBar>
 );

--- a/src/components/AssetListHeader.js
+++ b/src/components/AssetListHeader.js
@@ -7,9 +7,12 @@ import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
 
-const styles = {
+const styles = theme => ({
   flex: { flex: 1 },
-};
+  createButton: {
+    backgroundColor: theme.customColors.white,
+  },
+});
 
 /*
   Renders the app bar of the list view of Assets.
@@ -21,7 +24,7 @@ const AssetListHeader = ({ title, classes }) => (
         { title }
       </Typography>
       <Link className='App-raised-button-link' to="/asset/create">
-        <Button variant='raised'>Create Asset</Button>
+        <Button variant='raised' className={classes.createButton}>Create Asset</Button>
       </Link>
     </Toolbar>
   </AppBar>


### PR DESCRIPTION
Buttons in both headers are changed to white to contrast with the primary coloured Appbar.
Cancel button in the edit view is no longer raised.

Closes #13