### PR TITLE
AssetForm: make "private" default to false

### DIFF
--- a/src/containers/AssetForm.js
+++ b/src/containers/AssetForm.js
@@ -79,7 +79,7 @@ export const NEW_ASSET = {
   purpose: null,
   research: null,
   owner: null,
-  private: null,
+  private: false,
   personal_data: null,
   data_subject: [],
   data_category: [],

--- a/src/containers/AssetForm.test.js
+++ b/src/containers/AssetForm.test.js
@@ -208,3 +208,26 @@ afterEach(() => {
 function setDataOnInput(testInstance, name, value) {
   testInstance.findByProps({name: name}).props.onChange({target: {name: name, value}}, value);
 }
+
+/*
+  Default asset posted by form has non-null values where necessary.
+ */
+test('default asset has non-null values set correctly', () => {
+  fetch_mock.post(() => true, ASSET_FIXTURE);
+
+  const assetForm = <Route path="/asset/:assetId" component={AssetForm} />;
+
+  const store = createMockStore();
+  const testInstance = render(assetForm, {store, url: '/asset/create'});
+
+  // "click" the save button
+  testInstance.findByType(AssetFormHeader).props.onClick();
+
+  // Extract body of new asset
+  const post_action = store.getActions().find(action => action.type === ASSET_POST_REQUEST);
+  expect(post_action.meta.url).toEqual(ENDPOINT_ASSETS);
+  const newAsset = JSON.parse(post_action.meta.body);
+
+  // Check fields which should have values have values
+  expect(newAsset.private).toBe(false);
+});


### PR DESCRIPTION
The current AssetForm defaults to setting private as "null" which does not work with the current backend. Default it to "false".

Closes #47