### PR TITLE
asset list: display institutions using their lookup name

### DIFF
--- a/src/components/AssetListItem.js
+++ b/src/components/AssetListItem.js
@@ -16,6 +16,7 @@ import Tooltip from 'material-ui/Tooltip';
 import Menu, { MenuItem } from 'material-ui/Menu';
 import { FormattedRelative, FormattedDate, FormattedTime } from 'react-intl';
 import AssetStatus from './AssetStatus';
+import LookupInstitution from './LookupInstitution';
 import { withStyles } from 'material-ui/styles';
 
 const privateIconStyles = theme => ({
@@ -98,7 +99,7 @@ const AssetListItem = ({confirmDelete, asset, history}) => {
       <EditCell>
         {asset.is_complete !== null ? <AssetStatus isComplete={asset.is_complete} /> : null}
       </EditCell>
-      <EditCell>{asset.department}</EditCell>
+      <EditCell><LookupInstitution instid={asset.department} /></EditCell>
       <EditCell><PrivateIcon isPrivate={asset.private} /></EditCell>
       <EditCell>
         <Tooltip

--- a/src/components/FetchLookupInstitutions.js
+++ b/src/components/FetchLookupInstitutions.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { listInstitutions } from '../redux/actions/lookupApi';
+
+/**
+ * A component which causes institutions to be fetched from lookup when the user logs in and the
+ * list has not previously been fetched. Since this list needs only to be fetched once, place it
+ * *outside* of any dynamic routes, etc.
+ *
+ * The fetching waits until auth.isLoggedIn becomes true.
+ */
+const FetchLookupInstitutions = ({ isLoggedIn, institutionsWereFetched, listInstitutions }) => {
+  // The component renders to null but, as a side-effect of rendering, it will cause a fetch of
+  // institutions is they have not currently been fetched and isLoggedIn becomes true.
+
+  if(isLoggedIn && !institutionsWereFetched) { listInstitutions(); }
+
+  return null;
+}
+
+FetchLookupInstitutions.propTypes = {
+  isLoggedIn: PropTypes.bool.isRequired,
+  institutionsWereFetched: PropTypes.bool.isRequired,
+  listInstitutions: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ auth: { isLoggedIn }, lookupApi: { institutions } }) => ({
+  isLoggedIn,
+  // we break this out as a separate prop so that any extra information which gets added to the
+  // institutions state in future does not cause unnecessary re-renders.
+  institutionsWereFetched: institutions.fetchedAt !== null,
+});
+
+const mapDispatchToProps = { listInstitutions };
+
+export default connect(mapStateToProps, mapDispatchToProps)(FetchLookupInstitutions);

--- a/src/components/FetchLookupInstitutions.test.js
+++ b/src/components/FetchLookupInstitutions.test.js
@@ -1,0 +1,56 @@
+// mock the lookupApi actions module
+jest.mock('../redux/actions/lookupApi', () => {
+  const original = require.requireActual('../redux/actions/lookupApi');
+  return {
+    ...original,
+    listInstitutions: jest.fn(() => ({ type: 'mock-list-institutions-action' })),
+  };
+});
+
+import React from 'react';
+import FetchLookupInstitutions from './FetchLookupInstitutions';
+import { listInstitutions } from '../redux/actions/lookupApi';
+import { render, createMockStore, DEFAULT_INITIAL_STATE as initialState } from '../testutils';
+
+// A state with institutions populated and logged in.
+const MOCK_STATE = {
+  ...initialState,
+  auth: { ...initialState.auth, isLoggedIn: true },
+  lookupApi: {
+    ...initialState.lookupApi,
+    institutions: {
+      ...initialState.lookupApi.institutions,
+
+      fetchedAt: new Date(),
+
+      byInstid: new Map([
+        ['AAA', { instid: 'AAA', name: 'Dept of A' }],
+        ['BBB', { instid: 'BBB', name: 'Dept of B' }],
+      ]),
+    },
+  },
+};
+
+beforeEach(() => {
+  listInstitutions.mockClear();
+});
+
+test('Does not fetch if not logged in', () => {
+  const state = { ...initialState, auth: { ...initialState.auth, isLoggedIn: false } };
+  const store = createMockStore(state);
+  const testInstance = render(<FetchLookupInstitutions />, { store });
+  expect(listInstitutions.mock.calls).toHaveLength(0);
+});
+
+test('Does not fetch if institutions already fetched', () => {
+  const store = createMockStore(MOCK_STATE);
+  const testInstance = render(<FetchLookupInstitutions />, { store });
+  expect(listInstitutions.mock.calls).toHaveLength(0);
+});
+
+test('Does fetch if logged in but no institutions fetched yet', () => {
+  const state = { ...initialState, auth: { ...initialState.auth, isLoggedIn: true } };
+  const store = createMockStore(state);
+  const testInstance = render(<FetchLookupInstitutions />, { store });
+  expect(listInstitutions.mock.calls).toHaveLength(1);
+});

--- a/src/components/FetchLookupInstitutions.test.js
+++ b/src/components/FetchLookupInstitutions.test.js
@@ -8,6 +8,7 @@ jest.mock('../redux/actions/lookupApi', () => {
 });
 
 import React from 'react';
+import { Map } from 'immutable';
 import FetchLookupInstitutions from './FetchLookupInstitutions';
 import { listInstitutions } from '../redux/actions/lookupApi';
 import { render, createMockStore, DEFAULT_INITIAL_STATE as initialState } from '../testutils';
@@ -23,7 +24,7 @@ const MOCK_STATE = {
 
       fetchedAt: new Date(),
 
-      byInstid: new Map([
+      byInstid: Map([
         ['AAA', { instid: 'AAA', name: 'Dept of A' }],
         ['BBB', { instid: 'BBB', name: 'Dept of B' }],
       ]),

--- a/src/components/Lookup.test.js
+++ b/src/components/Lookup.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Autosuggest from 'react-autosuggest';
+import { Map } from 'immutable';
 import { Chip, TextField } from 'material-ui';
 import {render, createMockStore, DEFAULT_INITIAL_STATE, condition} from '../testutils';
 import Lookup from "./Lookup";
@@ -40,7 +41,7 @@ test('a Chip is rendered if value', () => {
     store: createMockStore({
       lookupApi: {
         ...DEFAULT_INITIAL_STATE.lookupApi,
-        peopleByCrsid: new Map([["msb999", PERSON_FIXTURE]])
+        peopleByCrsid: Map([["msb999", PERSON_FIXTURE]])
       }
     })
   });
@@ -57,7 +58,7 @@ test('deleting the Chip resets value', () => {
     store: createMockStore({
       lookupApi: {
         ...DEFAULT_INITIAL_STATE.lookupApi,
-        peopleByCrsid: new Map([["msb999", PERSON_FIXTURE]])
+        peopleByCrsid: Map([["msb999", PERSON_FIXTURE]])
       }
     })
   });

--- a/src/components/LookupInstitution.js
+++ b/src/components/LookupInstitution.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * A component which renders a Lookup institution given the institution id.
+ *
+ * Props:
+ *
+ *  * component: a node, defaults to 'span'. The underlying component used to render this
+ *    component. If will be given a single text child which is the institution name or id.
+ *  * componentProps: props to pass to the component
+ *  * instid: Lookup inst id to render.
+ */
+const LookupInstitution = ({
+  component: Component = 'span', componentProps = {}, institution, instid
+}) => (
+  <Component {...componentProps}>{ institution ? institution.name : instid }</Component>
+);
+
+const mapStateToProps = ({ lookupApi: { institutions }}, { instid }) => ({
+  institution: institutions.byInstid.get(instid),
+});
+
+export default connect(mapStateToProps)(LookupInstitution);

--- a/src/components/LookupInstitution.test.js
+++ b/src/components/LookupInstitution.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, createMockStore, DEFAULT_INITIAL_STATE as initialState } from '../testutils';
+import LookupInstitution from './LookupInstitution';
+
+const stateWithInstitutions = {
+  ...initialState,
+  lookupApi: {
+    ...initialState.lookupApi,
+    institutions: {
+      ...initialState.lookupApi.institutions,
+
+      fetchedAt: new Date(),
+      byInstid: new Map([
+        ['AAA', {
+          cancelled: false, instid: 'AAA', name: 'Department of AAA',
+          url: 'http://lookup.invalid/institutions/AAA'
+        }],
+        ['BBB', {
+          cancelled: false, instid: 'BBB', name: 'Faculty of BBB',
+          url: 'http://lookup.invalid/institutions/BBB'
+        }],
+      ]),
+    },
+  },
+};
+
+test('Can render empty component and it is a span', () => {
+  const testInstance = render(<LookupInstitution />);
+  expect(testInstance.findByType('span')).toBeDefined();
+});
+
+test('Can render empty component with non-span component and props', () => {
+  const testInstance = render(<LookupInstitution
+    component='div' componentProps={{ className: 'foo' }}/>);
+  expect(testInstance.findByType('div')).toBeDefined();
+  expect(testInstance.findByType('div').props).toEqual({ className: 'foo' });
+});
+
+test('Component uses instid if institution not in list', () => {
+  const store = createMockStore(stateWithInstitutions);
+  const testInstance = render(<LookupInstitution instid="CCC"/>, { store });
+  expect(testInstance.findByType('span').children).toEqual(['CCC']);
+});
+
+test('Component uses name if institution in list', () => {
+  const store = createMockStore(stateWithInstitutions);
+  const testInstance = render(<LookupInstitution instid="AAA"/>, { store });
+  expect(testInstance.findByType('span').children).toEqual(['Department of AAA']);
+});

--- a/src/components/LookupInstitution.test.js
+++ b/src/components/LookupInstitution.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Map } from 'immutable';
 import { render, createMockStore, DEFAULT_INITIAL_STATE as initialState } from '../testutils';
 import LookupInstitution from './LookupInstitution';
 
@@ -10,7 +11,7 @@ const stateWithInstitutions = {
       ...initialState.lookupApi.institutions,
 
       fetchedAt: new Date(),
-      byInstid: new Map([
+      byInstid: Map([
         ['AAA', {
           cancelled: false, instid: 'AAA', name: 'Department of AAA',
           url: 'http://lookup.invalid/institutions/AAA'

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -6,6 +6,7 @@ import { IntlProvider } from 'react-intl';
 import { DeleteConfirmationDialog, FetchSelf, ScrollToTop, Snackbar } from '../components';
 import PropTypes from 'prop-types';
 import AppRoutes from './AppRoutes';
+import FetchLookupInstitutions from '../components/FetchLookupInstitutions';
 import theme from '../style/CustomMaterialTheme';
 import '../style/App.css';
 
@@ -25,6 +26,7 @@ const App = ({ store }) => (
           <DeleteConfirmationDialog />
           <Snackbar />
           <FetchSelf />
+          <FetchLookupInstitutions />
         </div>
       </ReduxProvider>
     </IntlProvider>

--- a/src/redux/actions/lookupApi.js
+++ b/src/redux/actions/lookupApi.js
@@ -13,7 +13,12 @@ export const PEOPLE_GET_SELF_SUCCESS = Symbol('PEOPLE_GET_SELF_SUCCESS');
 export const PEOPLE_GET_SELF_FAILURE = Symbol('PEOPLE_GET_SELF_FAILURE');
 export const PEOPLE_GET_SELF_RESET = Symbol('PEOPLE_GET_SELF_RESET');
 
+export const INSTITUTIONS_LIST_REQUEST = Symbol('INSTITUTIONS_LIST_REQUEST');
+export const INSTITUTIONS_LIST_SUCCESS = Symbol('INSTITUTIONS_LIST_SUCCESS');
+export const INSTITUTIONS_LIST_FAILURE = Symbol('INSTITUTIONS_LIST_FAILURE');
+
 export const ENDPOINT_PEOPLE = process.env.REACT_APP_ENDPOINT_LOOKUP + 'people';
+export const ENDPOINT_INSTUTITIONS = process.env.REACT_APP_ENDPOINT_LOOKUP + 'institutions';
 
 /**
  * Fetch a list of people.
@@ -66,4 +71,15 @@ export const getSelf = () => ({
  */
 export const resetSelf = () => ({
   type: PEOPLE_GET_SELF_RESET,
+});
+
+/**
+ * Fetch a list of all institutions
+ */
+export const listInstitutions = () => ({
+  [RSAA]: {
+    endpoint: ENDPOINT_INSTUTITIONS,
+    method: 'GET',
+    types: [INSTITUTIONS_LIST_REQUEST, INSTITUTIONS_LIST_SUCCESS, INSTITUTIONS_LIST_FAILURE]
+  }
 });

--- a/src/redux/reducers/lookupApi.js
+++ b/src/redux/reducers/lookupApi.js
@@ -3,6 +3,7 @@ import {
   PEOPLE_GET_SELF_REQUEST, PEOPLE_GET_SELF_RESET, PEOPLE_GET_SELF_SUCCESS,
   PEOPLE_GET_SUCCESS,
   PEOPLE_LIST_SUCCESS,
+  INSTITUTIONS_LIST_SUCCESS,
 } from '../actions/lookupApi';
 
 import Cache from '../cache';
@@ -17,10 +18,19 @@ export const initialState = {
   // a cache of arrays of people records returned by the lookup api search endpoint -
   // keyed on the search text that produced the result.
   matchingPeopleByQuery: new Cache({maxSize: 20}),
+
   // the authenticated user's profile
   self: null,
   // whether or not the authenticated user's profile is being loaded
   selfLoading: false,
+
+  institutions: {
+    // If non-NULL, a JS Date object indicating when this was last fetched.
+    fetchedAt: null,
+
+    // A map of all institution records keyed by institution id.
+    byInstid: new Map(),
+  },
 };
 
 export default (state = initialState, action) => {
@@ -48,6 +58,19 @@ export default (state = initialState, action) => {
     case PEOPLE_GET_SELF_SUCCESS:
       // Add the person to the peopleByCrsid map
       return { ...state, self: action.payload, selfLoading: false};
+
+    case INSTITUTIONS_LIST_SUCCESS:
+      // Replace current institution list with returned results
+      return {
+        ...state,
+        institutions: {
+          ...state.institutions,
+          fetchedAt: new Date(),
+          byInstid: new Map(action.payload.results.map(
+            institution => [institution.instid, institution]
+          )),
+        },
+      };
 
     default:
       return state;

--- a/src/redux/reducers/lookupApi.js
+++ b/src/redux/reducers/lookupApi.js
@@ -29,7 +29,7 @@ export const initialState = {
     fetchedAt: null,
 
     // A map of all institution records keyed by institution id.
-    byInstid: new ImmutableMap(),
+    byInstid: ImmutableMap(),
   },
 };
 
@@ -66,7 +66,7 @@ export default (state = initialState, action) => {
         institutions: {
           ...state.institutions,
           fetchedAt: new Date(),
-          byInstid: new ImmutableMap(action.payload.results.map(
+          byInstid: ImmutableMap(action.payload.results.map(
             institution => [institution.instid, institution]
           )),
         },

--- a/src/redux/reducers/lookupApi.js
+++ b/src/redux/reducers/lookupApi.js
@@ -29,7 +29,7 @@ export const initialState = {
     fetchedAt: null,
 
     // A map of all institution records keyed by institution id.
-    byInstid: new Map(),
+    byInstid: new ImmutableMap(),
   },
 };
 
@@ -66,7 +66,7 @@ export default (state = initialState, action) => {
         institutions: {
           ...state.institutions,
           fetchedAt: new Date(),
-          byInstid: new Map(action.payload.results.map(
+          byInstid: new ImmutableMap(action.payload.results.map(
             institution => [institution.instid, institution]
           )),
         },

--- a/src/redux/reducers/lookupApi.test.js
+++ b/src/redux/reducers/lookupApi.test.js
@@ -137,3 +137,19 @@ test('institutions are copied from institution list success action', () => {
   expect(nextState.institutions.byInstid.get('AAA')).toEqual({ instid: 'AAA', name: 'Dept of A' });
   expect(nextState.institutions.byInstid.get('BBB')).toEqual({ instid: 'BBB', name: 'Dept of B' });
 });
+
+test('byInstid is an immutable map after update', () => {
+  const initialState = reducer(undefined, { type: 'not-an-action' });
+  expect(initialState.institutions.byInstid).toBeInstanceOf(Map);
+
+  const action = {
+    type: INSTITUTIONS_LIST_SUCCESS,
+    payload: { results: [
+      { instid: 'AAA', name: 'Dept of A' },
+      { instid: 'BBB', name: 'Dept of B' },
+    ] },
+  };
+
+  const nextState = reducer(initialState, action);
+  expect(nextState.institutions.byInstid).toBeInstanceOf(Map);
+});

--- a/src/redux/reducers/lookupApi.test.js
+++ b/src/redux/reducers/lookupApi.test.js
@@ -3,7 +3,7 @@ import { Map } from 'immutable';
 import reducer, { initialState } from './lookupApi';
 import {
   PEOPLE_GET_SELF_REQUEST, PEOPLE_GET_SELF_SUCCESS, PEOPLE_GET_SUCCESS,
-  PEOPLE_LIST_SUCCESS
+  PEOPLE_LIST_SUCCESS, INSTITUTIONS_LIST_SUCCESS
 } from '../actions/lookupApi';
 
 // test that the state is correctly initialised.
@@ -116,4 +116,24 @@ test("the authenticated user's profile is set in self", () => {
   expect(nextState.selfLoading).toBe(false);
   // check the state wasn't mutated
   expect(Object.is(initialState.self, nextState.self)).toBe(false);
+});
+
+test('institutions are copied from institution list success action', () => {
+  const initialState = reducer(undefined, { type: 'not-an-action' });
+  expect(initialState.institutions.fetchedAt).toBeNull();
+  expect(initialState.institutions.byInstid.get('AAA')).toBeUndefined();
+
+  const action = {
+    type: INSTITUTIONS_LIST_SUCCESS,
+    payload: { results: [
+      { instid: 'AAA', name: 'Dept of A' },
+      { instid: 'BBB', name: 'Dept of B' },
+    ] },
+  };
+
+  const nextState = reducer(initialState, action);
+
+  expect(nextState.institutions.fetchedAt).not.toBeNull();
+  expect(nextState.institutions.byInstid.get('AAA')).toEqual({ instid: 'AAA', name: 'Dept of A' });
+  expect(nextState.institutions.byInstid.get('BBB')).toEqual({ instid: 'BBB', name: 'Dept of B' });
 });


### PR DESCRIPTION
Add a list of institutions keyed by instid to the redux store and add a
new action, listInstitutions(), which will populate it.

Add a LookupInstitution component which renders a lookup instution given
the lookup instid falling back to using the instid.

The initial fetch is triggered by a FetchLookupInstitutions component
which will cause a fetch of institutions on first render if a fetch had
not previous occurred. This component is rendered outside of the router
component since it should only fetch on first page load, not on
navigation.

Closes #57.