### PR TITLE
reset all application state on logout

### DIFF
--- a/src/components/LogoutLink.js
+++ b/src/components/LogoutLink.js
@@ -2,14 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { logout } from '../redux/actions/auth';
-import { resetSelf } from "../redux/actions/lookupApi";
 
 /**
  * A link whose action will always log the current user out.
  */
-const LogoutLink = ({logout, resetSelf, children, ...rest}) => (
+const LogoutLink = ({logout, children, ...rest}) => (
   // eslint-disable-next-line
-  <a href="#" onClick={() => {logout(); resetSelf()}} {...rest}>{ children }</a>
+  <a href="#" onClick={logout} {...rest}>{ children }</a>
 );
 
 LogoutLink.propTypes = {
@@ -17,6 +16,6 @@ LogoutLink.propTypes = {
   logout: PropTypes.func.isRequired
 };
 
-const mapDispatchToProps = { logout, resetSelf };
+const mapDispatchToProps = { logout };
 
 export default connect(null, mapDispatchToProps)(LogoutLink);

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -5,7 +5,26 @@ import deleteConfirmation from './deleteConfirmation';
 import snackbar from './snackbar';
 import lookupApi from './lookupApi';
 
+import { LOGOUT } from 'redux-implicit-oauth2';
+
 /**
  * Combine all reducers used in the application together into one reducer.
  */
-export default combineReducers({ auth, assets, deleteConfirmation, snackbar, lookupApi });
+export const reducers = combineReducers({ auth, assets, deleteConfirmation, snackbar, lookupApi });
+
+/**
+ * The default export wraps all reducers in a catch all reducer which resets state on LOGOUT. This
+ * ensures that, by default, the state after logout is identical to a fresh load of the
+ * application. Reducers which want to do something special on LOGOUT may look at the
+ * "originalState" property which is added to the LOGOUT action. This property is given the
+ * original state before logout.
+ */
+export default (state, action) => {
+  // In the case of LOGOUT, we forcibly reset state to the initial state by passing undefined as
+  // the current state. Reducers which wish to do something special on LOGOUT may inspect the
+  // originalState parameter added to the action.
+  if(action.type === LOGOUT) { return reducers(undefined, { ...action, originalState: state }); }
+
+  // Otherwise, we pass the action to the usual reducer chain.
+  return reducers(state, action);
+};

--- a/src/redux/reducers/index.test.js
+++ b/src/redux/reducers/index.test.js
@@ -1,0 +1,30 @@
+// mock any components which are troublesome in our test suite
+import '../../test/mock-localstorage';
+
+// mock the underlying reducer returned by combineReducers() since we care only about the wrapped
+// reducer behaviour
+jest.mock('redux', () => {
+  const original = require.requireActual('redux');
+  const mockReducers = jest.fn();
+  return { ...original, combineReducers: () => mockReducers };
+});
+
+import { combineReducers } from 'redux';
+import wrappedReducers, { reducers } from './index';
+import { LOGOUT } from 'redux-implicit-oauth2';
+
+const mockReducers = combineReducers();
+
+beforeEach(() => {
+  mockReducers.mockClear();
+});
+
+test('wrappedReducer passes arguments to reducers', () => {
+  wrappedReducers('xxx', { type: 'test' });
+  expect(mockReducers.mock.calls).toEqual([['xxx', { type: 'test' }]]);
+});
+
+test('wrappedReducer passes undefined as state with logout action', () => {
+  wrappedReducers('xxx', { type: LOGOUT });
+  expect(mockReducers.mock.calls).toEqual([[undefined, { type: LOGOUT, originalState: 'xxx' }]]);
+});


### PR DESCRIPTION
LOGOUT is a special action in that potentially all state cached by the application becomes invalid.

Wrap the default reducer in an implementation which resets state by calling the reducers with undefined as the current state. Reducers are given a change to "save" something from the original state since it is added to the LOGOUT action as an originalState property but a "naive" reducer will just return the initial state for the application.

Closes #74