### PR TITLE
Reflect editable state of asset

### DIFF
--- a/src/components/AssetFormHeader.js
+++ b/src/components/AssetFormHeader.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import { withStyles } from 'material-ui/styles';
 import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
@@ -38,12 +37,7 @@ const AssetFormHeader = ({ onClick, asset, ownsAsset, classes }) => {
       title = 'Editing: ' + name;
     } else {
       title = 'Viewing: ' + name;
-      // overrides the default buttons with a simple back button
-      button = (
-        <Link className='App-raised-button-link' to="/">
-          <Button className={classes.cancelButton} color='primary'>Back</Button>
-        </Link>
-      );
+      button = <span/>;
     }
   }
 

--- a/src/components/AssetFormHeader.js
+++ b/src/components/AssetFormHeader.js
@@ -6,6 +6,7 @@ import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
 import Button from 'material-ui/Button';
+import {connect} from "react-redux";
 
 const styles = theme => ({
   flex: { flex: 1 },
@@ -13,28 +14,70 @@ const styles = theme => ({
   saveButton: { background: theme.customColors.white }
 });
 
-/*
-  Renders the app bar of the form for the creation/editing of an Asset.
-  */
-const AssetFormHeader = ({ title, onClick, classes }) => (
-  <AppBar position="static">
-    <Toolbar>
-      <Typography variant="title" color="inherit" className={classes.flex}>
-        { title }
-      </Typography>
+/**
+ * Renders the app bar of the form for the creation/editing/viewing of an Asset.
+ *
+ * @param onClick handles the save button
+ * @param asset either the asset being edited/viewed or null if we are creating an asset
+ * @param ownsAsset closure that decides if the user owns an asset.
+ */
+const AssetFormHeader = ({ onClick, asset, ownsAsset, classes }) => {
+
+  // the default title/buttons are for creating an asset
+  let title = 'Create new asset';
+  let buttons = (
+    <div>
       <Link className='App-raised-button-link' to="/">
         <Button className={classes.cancelButton} color='primary'>Cancel</Button>
       </Link>
       &nbsp;
       <Button className={classes.saveButton} variant="raised" onClick={onClick}>Save</Button>
-    </Toolbar>
-  </AppBar>
-);
+    </div>
+  );
 
-AssetFormHeader.propTypes = {
-  classes: PropTypes.object.isRequired,
-  title: PropTypes.string.isRequired,
-  onClick: PropTypes.func,
+  if (asset) {
+    // define the asset name
+    const name = asset.name ? asset.name : asset.id;
+
+    if (ownsAsset(asset)) {
+      title = 'Editing: ' + name;
+    } else {
+      title = 'Viewing: ' + name;
+      // overrides the default buttons with a simple back button
+      buttons = (
+        <Link className='App-raised-button-link' to="/">
+          <Button className={classes.cancelButton} color='primary'>Back</Button>
+        </Link>
+      );
+    }
+  }
+
+  return <AppBar position="static">
+    <Toolbar>
+      <Typography variant="title" color="inherit" className={classes.flex}>
+        { title }
+      </Typography>
+      {buttons}
+    </Toolbar>
+  </AppBar>;
 };
 
-export default withStyles(styles)(AssetFormHeader);
+AssetFormHeader.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  asset: PropTypes.object,
+  classes: PropTypes.object.isRequired,
+};
+
+const mapStateToProps = ({ lookupApi: { self } }) => {
+
+  const institutions = self && self.institutions ? self.institutions : [];
+
+  // closure that decides if the user owns an asset.
+  const ownsAsset = (asset) => (
+    institutions.find((institution) => institution.instid === asset.department)
+  );
+
+  return { ownsAsset };
+};
+
+export default connect(mapStateToProps)(withStyles(styles)(AssetFormHeader));

--- a/src/components/AssetFormHeader.test.js
+++ b/src/components/AssetFormHeader.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import {render, createMockStore, DEFAULT_INITIAL_STATE} from '../testutils';
+import {Typography, Button} from "material-ui";
+import AssetFormHeader from "./AssetFormHeader";
+
+const ASSET_FIXTURE = {name: 'An asset', department: 'UIS'};
+
+const HEADER_WITH_ASSET = <AssetFormHeader asset={ASSET_FIXTURE} onClick={() => {}}/>;
+
+test('"create new asset" header is created with correct title and buttons', () => {
+
+  const store = createMockStore();
+
+  const testInstance = render(<AssetFormHeader onClick={() => {}}/>, { store, url: '/' });
+
+  expect(testInstance.findByType(Typography).props.children).toBe('Create new asset');
+  const buttons = testInstance.findAllByType(Button);
+  expect(buttons).toHaveLength(2);
+  expect(buttons[0].props.children).toBe('Cancel');
+  expect(buttons[1].props.children).toBe('Save');
+});
+
+test('"view asset" header is created with correct title and buttons', () => {
+
+  const testInstance = render(HEADER_WITH_ASSET, { store: createMockStore(), url: '/' });
+
+  expect(testInstance.findByType(Typography).props.children).toBe('Viewing: An asset');
+  expect(testInstance.findByType(Button).props.children).toBe('Back');
+});
+
+test('"edit asset" header is created with correct title and buttons', () => {
+
+  const store = createMockStore({...DEFAULT_INITIAL_STATE, lookupApi: {
+      ...DEFAULT_INITIAL_STATE.lookupApi,
+      self: {
+      institutions: [
+        {instid: 'UIS', name: 'University Information Services'}
+      ]
+    }
+  }});
+
+  const testInstance = render(HEADER_WITH_ASSET, { store, url: '/' });
+
+  expect(testInstance.findByType(Typography).props.children).toBe('Editing: An asset');
+  const buttons = testInstance.findAllByType(Button);
+  expect(buttons).toHaveLength(2);
+  expect(buttons[0].props.children).toBe('Cancel');
+  expect(buttons[1].props.children).toBe('Save');
+});

--- a/src/components/AssetFormHeader.test.js
+++ b/src/components/AssetFormHeader.test.js
@@ -14,10 +14,7 @@ test('"create new asset" header is created with correct title and buttons', () =
   const testInstance = render(<AssetFormHeader onClick={() => {}}/>, { store, url: '/' });
 
   expect(testInstance.findByType(Typography).props.children).toBe('Create new asset');
-  const buttons = testInstance.findAllByType(Button);
-  expect(buttons).toHaveLength(2);
-  expect(buttons[0].props.children).toBe('Cancel');
-  expect(buttons[1].props.children).toBe('Save');
+  expect(testInstance.findByType(Button).props.children).toBe('Save');
 });
 
 test('"view asset" header is created with correct title and buttons', () => {
@@ -25,7 +22,7 @@ test('"view asset" header is created with correct title and buttons', () => {
   const testInstance = render(HEADER_WITH_ASSET, { store: createMockStore(), url: '/' });
 
   expect(testInstance.findByType(Typography).props.children).toBe('Viewing: An asset');
-  expect(testInstance.findByType(Button).props.children).toBe('Back');
+  expect(testInstance.findAllByType(Button)).toHaveLength(0);
 });
 
 test('"edit asset" header is created with correct title and buttons', () => {
@@ -42,8 +39,5 @@ test('"edit asset" header is created with correct title and buttons', () => {
   const testInstance = render(HEADER_WITH_ASSET, { store, url: '/' });
 
   expect(testInstance.findByType(Typography).props.children).toBe('Editing: An asset');
-  const buttons = testInstance.findAllByType(Button);
-  expect(buttons).toHaveLength(2);
-  expect(buttons[0].props.children).toBe('Cancel');
-  expect(buttons[1].props.children).toBe('Save');
+  expect(testInstance.findByType(Button).props.children).toBe('Save');
 });

--- a/src/containers/AppRoutes.test.js
+++ b/src/containers/AppRoutes.test.js
@@ -29,7 +29,9 @@ test('can render /assets/UIS', () => {
   };
   const testInstance = render(<AppRoutes/>, {
     url: '/assets/UIS',
-    store: createMockStore({...DEFAULT_INITIAL_STATE, lookupApi: {self}})
+    store: createMockStore({...DEFAULT_INITIAL_STATE, lookupApi: {
+      ...DEFAULT_INITIAL_STATE.lookupApi, self
+    }})
   });
 
   expect(appBarTitle(testInstance)).toBe('Assets: University Information Services')
@@ -57,13 +59,25 @@ test('can render /asset/e20f4cd4-9f97-4829-8178-476c7a67eb97', () => {
 
   const assetsByUrl = new Map([[
     process.env.REACT_APP_ENDPOINT_ASSETS + 'e20f4cd4-9f97-4829-8178-476c7a67eb97/', {
-      asset: {name: 'Super Secret Medical Data'}
+      asset: {
+        name: 'Super Secret Medical Data',
+        department: 'UIS'
+      }
     }
   ]]);
 
   const testInstance = render(<AppRoutes/>, {
     url: '/asset/e20f4cd4-9f97-4829-8178-476c7a67eb97',
-    store: createMockStore({...DEFAULT_INITIAL_STATE, assets: {assetsByUrl}})
+    store: createMockStore({
+      ...DEFAULT_INITIAL_STATE,
+      assets: {assetsByUrl},
+      lookupApi: {
+        ...DEFAULT_INITIAL_STATE.lookupApi,
+        self: {
+          institutions: [{instid: 'UIS', name: 'University Information Services'}]
+        }
+      }
+    })
   });
 
   expect(appBarTitle(testInstance)).toBe('Editing: Super Secret Medical Data')

--- a/src/containers/AssetForm.js
+++ b/src/containers/AssetForm.js
@@ -163,7 +163,7 @@ class AssetForm extends Component {
       <Page>
         <AssetFormHeader
           onClick={() => this.handleSave()}
-          title={this.props.assetUrl ? 'Editing: ' + (this.state.name ? this.state.name : this.state.id) : 'Create new asset'}
+          asset={this.props.assetUrl ? this.state : null}
         />
 
         <Grid container>


### PR DESCRIPTION
closes: #20 
At present this is done purely in the AssetFormHeader by restricting the buttons in "view" mode.