### PR TITLE
add REACT_APP_OAUTH_REDIRECT setting for configuring Oauth2 redirect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,9 @@ Note that you must re-run `npm start` for config to take effect.
 Also note all vars names **must** be frefixed with `REACT_APP_`.
 See the [documentation](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-development-environment-variables-in-env) for more information.
 
+Settings which are not included in the [shipped .env file](.env) but which may
+also be of use are:
+
+* **REACT_APP_BASENAME**: basename of app if not served from the web server
+    root. Make sure to include trailing and leading slashes.
+* **REACT_APP_OAUTH_REDIRECT**: redirect URL passed to OAuth2 server.

--- a/src/redux/actions/auth.js
+++ b/src/redux/actions/auth.js
@@ -7,13 +7,18 @@
  */
 import { login as implicitLogin, logout as implicitLogout } from 'redux-implicit-oauth2';
 
+// construct the OAuth2 redirect URL if not specified.
+const basename = process.env.REACT_APP_BASENAME || '/';
+const redirect =
+  process.env.REACT_APP_OAUTH_REDIRECT || window.location.origin + basename + 'oauth2-callback';
+
 /**
  * OAuth2 credentials configuration for the IAR frontend application.
  */
 const config = {
   url: process.env.REACT_APP_OAUTH_ENDPOINT,
   client: process.env.REACT_APP_OAUTH_CLIENT,
-  redirect: window.location.origin + '/oauth2-callback',  // HACK: get the base URL of the website
+  redirect: redirect,
   scope: process.env.REACT_APP_OAUTH_SCOPES,
   width: 500, // Width (in pixels) of login popup window. Optional, default: 400
   height: 400 // Height (in pixels) of login popup window. Optional, default: 400


### PR DESCRIPTION
The OAuth2 redirect URL was constructed with no regard to basename.
Allow it to be overridden via a setting. If the setting is not provided,
it is constructed.