### PR TITLE
src/index.js: un register the service worker

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './style/index.css';
 import App from './containers/App';
-import registerServiceWorker from './registerServiceWorker';
+import { unregister } from './registerServiceWorker';
 import configureStore from './redux/store';
 
 configureStore().then(({store}) => {
   ReactDOM.render(<App store={store}/>, document.getElementById('root'));
-  registerServiceWorker();
+  // Un-register any previous service worker we registered for this app.
+  // For the moment we remain an online-only application until we're sure that we don't need to
+  // roll out rapid iterations.
+  unregister();
 });


### PR DESCRIPTION
As noted in #91, the service worker we register in index.js provides an additional level of offline caching for the application. This provides very rapid load times on, e.g., Google Chrome but has the downside that updates to the application may take 24 hours to propagate.

While we still may make lock-step backend/frontend changes, disable and un-register (if registered) the service worker. We can re-visit this once the application stabilises.

Closes #91.