### PR TITLE
sanitise an edited asset before saving

### DIFF
--- a/src/assets.js
+++ b/src/assets.js
@@ -1,0 +1,46 @@
+/**
+ * Module containing utility functions for asset resources.
+ */
+
+/**
+ * Pre-save sanitisation.
+ */
+export const sanitise = asset => {
+  let sanitisedAsset = asset;
+
+  // Clear personal data fields if personal_data is false (but not null)
+  if(asset.personal_data === false) {
+    sanitisedAsset = {
+      ...sanitisedAsset,
+      data_subject: [], data_category: [], retention: null,
+      recipients_outside_eea: null, recipients_outside_eea_description: null,
+      recipients_outside_uni: null, recipients_outside_uni_description: null,
+    };
+  }
+
+  // If personal data is true, sanitise recipients_outside_{...} fields
+  if(asset.personal_data === true) {
+    if(asset.recipients_outside_eea !== 'yes') {
+      sanitisedAsset = {
+        ...sanitisedAsset, recipients_outside_eea_description: null,
+      };
+    }
+    if(asset.recipients_outside_uni !== 'yes') {
+      sanitisedAsset = {
+        ...sanitisedAsset, recipients_outside_uni_description: null,
+      };
+    }
+  }
+
+  // If not a digital asset...
+  if(asset.storage_format && (asset.storage_format.indexOf('digital') === -1)) {
+    sanitisedAsset = { ...sanitisedAsset, digital_storage_security: [] };
+  }
+
+  // If not a paper asset...
+  if(asset.storage_format && (asset.storage_format.indexOf('paper') === -1)) {
+    sanitisedAsset = { ...sanitisedAsset, paper_storage_security: [] };
+  }
+
+  return sanitisedAsset;
+};

--- a/src/assets.test.js
+++ b/src/assets.test.js
@@ -1,0 +1,145 @@
+import { DEFAULT_ASSET } from './redux/actions/editAsset';
+import { sanitise } from './assets';
+
+let asset;
+
+beforeEach(() => {
+  asset = { ...DEFAULT_ASSET };
+});
+
+describe('sanitise', () => {
+  const pd_clear_fields = [
+    'retention', 'recipients_outside_eea', 'recipients_outside_eea_description',
+    'recipients_outside_uni', 'recipients_outside_uni_description',
+  ];
+
+  describe('passed asset with personal_data = false', () => {
+    beforeEach(() => {
+      asset.personal_data = false;
+    });
+
+    test('clears data_subject', () => {
+      asset.data_subject = ['test'];
+      expect(sanitise(asset).data_subject).toHaveLength(0);
+    });
+
+    test('clears data_category', () => {
+      asset.data_category = ['test'];
+      expect(sanitise(asset).data_category).toHaveLength(0);
+    });
+
+    pd_clear_fields.forEach(field => {
+      test('clears ' + field, () => {
+        asset[field] = 'test';
+        expect(sanitise(asset)[field]).toBe(null);
+      });
+    });
+  });
+
+  describe('passed asset with personal_data = true', () => {
+    beforeEach(() => {
+      asset.personal_data = true;
+      asset.recipients_outside_eea = 'yes';
+      asset.recipients_outside_uni = 'yes';
+    });
+
+    test('preserves data_subject', () => {
+      asset.data_subject = ['test'];
+      expect(sanitise(asset).data_subject).toEqual(['test']);
+    });
+
+    test('preserves data_category', () => {
+      asset.data_category = ['test'];
+      expect(sanitise(asset).data_category).toEqual(['test']);
+    });
+
+    pd_clear_fields.forEach(field => {
+      test('preserves ' + field, () => {
+        asset[field] = 'test';
+        expect(sanitise(asset)[field]).toBe('test');
+      });
+    });
+
+    describe('with recipients_outside_eea = yes', () => {
+      beforeEach(() => {
+        asset.recipients_outside_eea = 'yes';
+      });
+
+      test('preserves recipients_outside_eea_description', () => {
+        asset.recipients_outside_eea_description = 'test';
+        expect(sanitise(asset)).toMatchObject({ recipients_outside_eea_description: 'test' });
+      });
+    });
+
+    describe('with recipients_outside_eea != yes', () => {
+      beforeEach(() => {
+        asset.recipients_outside_eea = 'definitely-not-yes';
+      });
+
+      test('clear recipients_outside_eea_description', () => {
+        asset.recipients_outside_eea_description = 'test';
+        expect(sanitise(asset)).toMatchObject({ recipients_outside_eea_description: null });
+      });
+    });
+
+    describe('with recipients_outside_uni = yes', () => {
+      beforeEach(() => {
+        asset.recipients_outside_uni = 'yes';
+      });
+
+      test('preserves recipients_outside_uni_description', () => {
+        asset.recipients_outside_uni_description = 'test';
+        expect(sanitise(asset)).toMatchObject({ recipients_outside_uni_description: 'test' });
+      });
+    });
+
+    describe('with recipients_outside_uni != yes', () => {
+      beforeEach(() => {
+        asset.recipients_outside_uni = 'definitely-not-yes';
+      });
+
+      test('clear recipients_outside_uni_description', () => {
+        asset.recipients_outside_uni_description = 'test';
+        expect(sanitise(asset)).toMatchObject({ recipients_outside_uni_description: null });
+      });
+    });
+  });
+
+  describe('passed asset with no digital asset', () => {
+    beforeEach(() => {
+      asset.storage_format = ['paper'];
+    });
+
+    test('clears digital_storage_security', () => {
+      asset.digital_storage_security = ['test'];
+      expect(sanitise(asset)).toMatchObject({ digital_storage_security: [] });
+    });
+  });
+
+  describe('passed asset with no paper asset', () => {
+    beforeEach(() => {
+      asset.storage_format = ['digital'];
+    });
+
+    test('clears paper_storage_security', () => {
+      asset.paper_storage_security = ['test'];
+      expect(sanitise(asset)).toMatchObject({ paper_storage_security: [] });
+    });
+  });
+
+  describe('passed asset with digital and paper asset', () => {
+    beforeEach(() => {
+      asset.storage_format = ['digital', 'paper'];
+    });
+
+    test('preserves digital_storage_security', () => {
+      asset.digital_storage_security = ['test'];
+      expect(sanitise(asset)).toMatchObject({ digital_storage_security: ['test'] });
+    });
+
+    test('preserves paper_storage_security', () => {
+      asset.paper_storage_security = ['test'];
+      expect(sanitise(asset)).toMatchObject({ paper_storage_security: ['test'] });
+    });
+  });
+});

--- a/src/redux/actions/editAsset.js
+++ b/src/redux/actions/editAsset.js
@@ -1,4 +1,5 @@
 import { getAsset, putAsset, postAsset } from './assetRegisterApi';
+import { sanitise } from '../../assets';
 
 export const SET_DRAFT = Symbol('SET_DRAFT');
 export const PATCH_DRAFT = Symbol('PATCH_DRAFT');
@@ -120,11 +121,14 @@ export const patchDraft = patch => ({
 export const saveDraft = () => (dispatch, getState) => {
   const { editAsset: { draft } } = getState();
 
+  // Make any fixes to the draft prior to saving
+  const sanitisedDraft = sanitise(draft);
+
   if(draft.url) {
     // asset has an existing URL so it should be PUT
-    return dispatch(putAsset(draft));
+    return dispatch(putAsset(sanitisedDraft));
   } else {
     // asset does not have an existing URL, so it should be POST-ed
-    return dispatch(postAsset(draft));
+    return dispatch(postAsset(sanitisedDraft));
   }
 };

--- a/src/redux/actions/editAsset.test.js
+++ b/src/redux/actions/editAsset.test.js
@@ -6,6 +6,17 @@ jest.mock('./assetRegisterApi', () => {
   return {
     ...original,
     getAsset: jest.fn(() => ({ type: 'mock-get-asset-action' })),
+    putAsset: jest.fn(() => ({ type: 'mock-put-asset-action' })),
+    postAsset: jest.fn(() => ({ type: 'mock-post-asset-action' })),
+  };
+});
+
+// mock the assets utility module
+jest.mock('../../assets', () => {
+  const original = require.requireActual('../../assets');
+  return {
+    ...original,
+    sanitise: jest.fn(draft => draft),
   };
 });
 
@@ -13,13 +24,14 @@ import globalReducer from '../reducers';
 import { DEFAULT_INITIAL_STATE } from '../../testutils';
 import {
   SET_DRAFT, PATCH_DRAFT, FETCH_DRAFT_REQUEST, FETCH_DRAFT_SUCCESS,
-  fetchOrCreateDraft
+  fetchOrCreateDraft, saveDraft, DEFAULT_ASSET
 } from './editAsset';
 
 import {
   ASSET_GET_REQUEST, ASSET_GET_SUCCESS,
-  getAsset,
+  getAsset, putAsset, postAsset,
 } from './assetRegisterApi';
+import { sanitise } from '../../assets';
 
 // mock GET-ing an asset. Returns new state.
 const mockGetAsset = (state, url, asset) => {
@@ -32,6 +44,9 @@ const mockGetAsset = (state, url, asset) => {
 
 beforeEach(() => {
   getAsset.mockClear();
+  putAsset.mockClear();
+  postAsset.mockClear();
+  sanitise.mockClear();
 });
 
 describe('fetchOrCreateDraft', () => {
@@ -105,6 +120,65 @@ describe('fetchOrCreateDraft', () => {
       const requestAction = dispatch.mock.calls[2][0];
       expect(requestAction.type).toBe(FETCH_DRAFT_SUCCESS);
       expect(requestAction.payload.asset).toBe(mockAsset);
+    });
+  });
+});
+
+describe('saveDraft', () => {
+  let draft, getState, dispatch;
+
+  beforeEach(() => {
+    draft = { ...DEFAULT_ASSET };
+
+    // mock up enough of the editAsset state for the actions to work.
+    getState = () => ({
+      editAsset: { draft },
+    });
+
+    // mock the dispatch function
+    dispatch = jest.fn();
+  });
+
+  test('is a thunk', () => {
+    expect(typeof saveDraft()).toBe('function');
+  });
+
+  test('calls sanitise on the draft before saving', () => {
+    saveDraft()(dispatch, getState);
+    expect(sanitise).toHaveBeenCalledWith(draft);
+  });
+
+  describe('when given draft with URL', () => {
+    beforeEach(() => {
+      draft.url = 'http://iar-backend.invalid/xxx';
+    });
+
+    test('PUTs it', () => {
+      saveDraft()(dispatch, getState);
+      expect(putAsset).toHaveBeenCalledWith(draft);
+      expect(dispatch).toHaveBeenCalledWith({ type: 'mock-put-asset-action' });
+    });
+
+    test('PUTs the sanitised draft', () => {
+      const sanitisedDraft = { name: 'test draft' };
+      sanitise.mockImplementationOnce(() => sanitisedDraft);
+      saveDraft()(dispatch, getState);
+      expect(putAsset).toHaveBeenCalledWith(sanitisedDraft);
+    });
+  });
+
+  describe('when given draft with no URL', () => {
+    test('POSTs it', () => {
+      saveDraft()(dispatch, getState);
+      expect(postAsset).toHaveBeenCalledWith(draft);
+      expect(dispatch).toHaveBeenCalledWith({ type: 'mock-post-asset-action' });
+    });
+
+    test('POSTs the sanitised draft', () => {
+      const sanitisedDraft = { name: 'test draft' };
+      sanitise.mockImplementationOnce(() => sanitisedDraft);
+      saveDraft()(dispatch, getState);
+      expect(postAsset).toHaveBeenCalledWith(sanitisedDraft);
     });
   });
 });


### PR DESCRIPTION
When saving an asset, sanitise the fields before saving. Specifically:

- if the asset does not contain private data, clear the private fields.
- if the asset is not shared outside the University, clear the
  description of who it is shared with.
- if the asset is not shared outside the EEA, clear the description of
  who it is shared with.
- if the asset is not digital, clear the digital security measures.
- if the asset is not physical, clear the physical security measures.

Closes #64