### PR TITLE
request confirmation when navigating away from an unsaved entry

### DIFF
--- a/src/AssetDetail/presentational/AssetForm.js
+++ b/src/AssetDetail/presentational/AssetForm.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 
+import PreventNavigationWhenDraftModified from '../../containers/PreventNavigationWhenDraftModified';
+
 import FetchOrCreateDraft from '../containers/FetchOrCreateDraft';
 
 import AssetPage from './AssetPage';
@@ -22,6 +24,8 @@ const AssetForm = ({ classes }) => (
       {/* When this component mounts, it checks the current route match and either begins a new draft
         * or loads an existing asset. */}
       <FetchOrCreateDraft />
+
+      <PreventNavigationWhenDraftModified />
     </AssetPage>
 );
 

--- a/src/containers/PreventNavigationWhenDraftModified.js
+++ b/src/containers/PreventNavigationWhenDraftModified.js
@@ -1,0 +1,53 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+
+const BLOCK_PROMPT =
+  'This entry has not yet been saved. Navigating away will cause any changes you have made to be lost.';
+
+/**
+ * A component which keeps tabs on the isModified state of the current draft and prevents
+ * navigation when it is being modified.
+ */
+class PreventNavigationWhenDraftModified extends Component {
+  constructor(...args) {
+    super(...args);
+
+    // store the "unblock" function returned from history.block. If this is non-null, it's an
+    // indication that we are blocking navigation
+    this.unblock = null;
+
+    this.updateBlock(this.props);
+  }
+
+  componentWillReceiveProps(newProps) {
+    this.updateBlock(newProps);
+  }
+
+  updateBlock({ history, isModified }) {
+    // cancel any existing block if draft becomes un-modified
+    if(!isModified && this.unblock) { this.unblock(); this.unblock = null; }
+
+    // if this draft becomes modified and we're not already blocking, do so
+    if(isModified && !this.unblock) { this.unblock = history.block(BLOCK_PROMPT); }
+  }
+
+  componentWillUnmount() {
+    // cancel any existing block if this component is unmounted
+    if(this.unblock) { this.unblock(); this.unblock = null; }
+  }
+
+  render() { return null; }
+}
+
+PreventNavigationWhenDraftModified.propTypes = {
+  history: PropTypes.shape({
+    block: PropTypes.func.isRequired,
+  }).isRequired,
+  isModified: PropTypes.bool.isRequired,
+};
+
+const mapStateToProps = ({ editAsset: { isModified } }) => ({ isModified });
+
+export default connect(mapStateToProps)(withRouter(PreventNavigationWhenDraftModified))

--- a/src/draft/draft.test.js
+++ b/src/draft/draft.test.js
@@ -16,7 +16,7 @@ describe('withDraft', () => {
     const Component = withDraft(mapDraftToProps)(() => null);
     render(<Component />, { store });
     expect(mapDraftToProps.mock.calls[0][0]).toEqual({
-      draft: draftSymbol, isLoading: false, isLive: true
+      draft: draftSymbol, isLoading: false, isLive: true, isModified: false,
     });
     expect(mapDraftToProps.mock.calls[0][1]).toEqual({ });
     expect(typeof mapDraftToProps.mock.calls[0][2].fetchOrCreateDraft).toBe('function');

--- a/src/redux/actions/editAsset.js
+++ b/src/redux/actions/editAsset.js
@@ -5,6 +5,7 @@ export const SET_DRAFT = Symbol('SET_DRAFT');
 export const PATCH_DRAFT = Symbol('PATCH_DRAFT');
 export const FETCH_DRAFT_REQUEST = Symbol('FETCH_DRAFT_REQUEST');
 export const FETCH_DRAFT_SUCCESS = Symbol('FETCH_DRAFT_SUCCESS');
+export const SAVE_DRAFT_SUCCESS = Symbol('SAVE_DRAFT_SUCCESS');
 
 // Default values for a new asset
 export const DEFAULT_ASSET = {
@@ -113,11 +114,17 @@ export const saveDraft = () => (dispatch, getState) => {
   // Make any fixes to the draft prior to saving
   const sanitisedDraft = sanitise(draft);
 
-  if(draft.url) {
-    // asset has an existing URL so it should be PUT
-    return dispatch(putAsset(sanitisedDraft));
-  } else {
-    // asset does not have an existing URL, so it should be POST-ed
-    return dispatch(postAsset(sanitisedDraft));
-  }
+  // Depending on whether draft.url is set, PUT or POST the asset saving the resulting promise.
+  const savePromise = dispatch(
+    draft.url ? putAsset(sanitisedDraft) : postAsset(sanitisedDraft)
+  );
+
+  return savePromise.then(action => {
+    const { error } = action;
+
+    // if save was successful, dispatch an action to indicate that the draft was saved
+    if(!error) { dispatch({ type: SAVE_DRAFT_SUCCESS }); }
+
+    return action;
+  });
 };

--- a/src/redux/actions/editAsset.test.js
+++ b/src/redux/actions/editAsset.test.js
@@ -23,7 +23,7 @@ jest.mock('../../assets', () => {
 import globalReducer from '../reducers';
 import { DEFAULT_INITIAL_STATE } from '../../testutils';
 import {
-  SET_DRAFT, PATCH_DRAFT, FETCH_DRAFT_REQUEST, FETCH_DRAFT_SUCCESS,
+  SET_DRAFT, PATCH_DRAFT, FETCH_DRAFT_REQUEST, FETCH_DRAFT_SUCCESS, SAVE_DRAFT_SUCCESS,
   fetchOrCreateDraft, saveDraft, DEFAULT_ASSET
 } from './editAsset';
 
@@ -136,7 +136,7 @@ describe('saveDraft', () => {
     });
 
     // mock the dispatch function
-    dispatch = jest.fn();
+    dispatch = jest.fn(value => Promise.resolve(value));
   });
 
   test('is a thunk', () => {
@@ -165,6 +165,12 @@ describe('saveDraft', () => {
       saveDraft()(dispatch, getState);
       expect(putAsset).toHaveBeenCalledWith(sanitisedDraft);
     });
+
+    test('dispatches a SAVE_DRAFT_SUCCESS after', () => {
+      saveDraft()(dispatch, getState).then(() => {
+        expect(dispatch).toHaveBeenLastCalledWith({ type: SAVE_DRAFT_SUCCESS });
+      });
+    });
   });
 
   describe('when given draft with no URL', () => {
@@ -179,6 +185,12 @@ describe('saveDraft', () => {
       sanitise.mockImplementationOnce(() => sanitisedDraft);
       saveDraft()(dispatch, getState);
       expect(postAsset).toHaveBeenCalledWith(sanitisedDraft);
+    });
+
+    test('dispatches SAVE_DRAFT_SUCCESS afterwards', () => {
+      saveDraft()(dispatch, getState).then(() => {
+        expect(dispatch).toHaveBeenLastCalledWith({ type: SAVE_DRAFT_SUCCESS });
+      });
     });
   });
 });

--- a/src/redux/reducers/editAsset.js
+++ b/src/redux/reducers/editAsset.js
@@ -1,5 +1,5 @@
 import {
-  SET_DRAFT, PATCH_DRAFT, FETCH_DRAFT_REQUEST, FETCH_DRAFT_SUCCESS
+  SET_DRAFT, PATCH_DRAFT, FETCH_DRAFT_REQUEST, FETCH_DRAFT_SUCCESS, SAVE_DRAFT_SUCCESS
 } from '../actions/editAsset';
 
 export const initialState = {
@@ -43,6 +43,8 @@ export default (state = initialState, action) => {
         ? action.payload.patch(state.draft) : action.payload.patch;
       return { ...state, draft: { ...state.draft, ...patch }, isModified: true };
     }
+    case SAVE_DRAFT_SUCCESS:
+      return { ...state, isModified: false };
     default:
       return state;
   }

--- a/src/redux/reducers/editAsset.js
+++ b/src/redux/reducers/editAsset.js
@@ -13,22 +13,27 @@ export const initialState = {
 
   // True if the draft is "live", i.e. it was successfully set via fetchOrCreateDraft
   isLive: false,
+
+  // True if the draft has been modified from its initial fetched or set state.
+  isModified: false,
 };
 
 export default (state = initialState, action) => {
   switch(action.type) {
     case SET_DRAFT:
       // replace the entire draft
-      return { ...state, draft: action.payload.draft, isLoading: false, isLive: true };
+      return {
+        ...state, draft: action.payload.draft, isLoading: false, isLive: true, isModified: false
+      };
     case FETCH_DRAFT_REQUEST: {
       // a new draft is loading
       const { url } = action.payload;
-      return { ...state, draft: { url }, isLoading: true, isLive: false };
+      return { ...state, draft: { url }, isLoading: true, isLive: false, isModified: false };
     }
     case FETCH_DRAFT_SUCCESS: {
       // draft was loaded
       const { asset } = action.payload;
-      return { ...state, draft: asset, isLoading: false, isLive: true };
+      return { ...state, draft: asset, isLoading: false, isLive: true, isModified: false };
     }
     case PATCH_DRAFT: {
       // update fields in the current draft based on the patch or the value returned from the patch
@@ -36,7 +41,7 @@ export default (state = initialState, action) => {
       const patch =
         (typeof action.payload.patch === 'function')
         ? action.payload.patch(state.draft) : action.payload.patch;
-      return { ...state, draft: { ...state.draft, ...patch } };
+      return { ...state, draft: { ...state.draft, ...patch }, isModified: true };
     }
     default:
       return state;

--- a/src/redux/reducers/editAsset.test.js
+++ b/src/redux/reducers/editAsset.test.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from './editAsset';
 import {
-  SET_DRAFT, PATCH_DRAFT, FETCH_DRAFT_REQUEST, FETCH_DRAFT_SUCCESS,
+  SET_DRAFT, PATCH_DRAFT, FETCH_DRAFT_REQUEST, FETCH_DRAFT_SUCCESS, SAVE_DRAFT_SUCCESS,
   patchDraft
 } from '../actions/editAsset';
 
@@ -85,5 +85,19 @@ describe('a PATCH_DRAFT action', () => {
     expect(state.isModified).toBe(false);
     state = reducer(state, patchDraft(patch));
     expect(state.isModified).toBe(true);
+  });
+});
+
+describe('a SAVE_DRAFT_SUCCESS action', () => {
+  let previousMockDraft, expectedMockDraft;
+  beforeEach(() => {
+    state = reducer(state, { type: SET_DRAFT, payload: { draft: mockDraft } });
+    state.isModified = true;
+  });
+
+  test('resets isModified', () => {
+    expect(state.isModified).toBe(true);
+    state = reducer(state, { type: SAVE_DRAFT_SUCCESS });
+    expect(state.isModified).toBe(false);
   });
 });

--- a/src/redux/reducers/editAsset.test.js
+++ b/src/redux/reducers/editAsset.test.js
@@ -13,40 +13,49 @@ beforeEach(() => {
 });
 
 describe('a SET_DRAFT action', () => {
-  let state;
   beforeEach(() => {
+    state.isLoading = true;
+    state.isModified = true;
+    state.isLive = false;
     state = reducer(state, { type: SET_DRAFT, payload: { draft: mockDraft } });
   });
 
   test('sets draft', () => { expect(state.draft).toBe(mockDraft); });
   test('clears isLoading', () => { expect(state.isLoading).toBe(false); });
   test('sets isLive', () => { expect(state.isLive).toBe(true); });
+  test('clears isModified', () => { expect(state.isModified).toBe(false); });
 });
 
 describe('a FETCH_DRAFT_REQUEST action', () => {
-  let state;
   beforeEach(() => {
+    state.isLoading = false;
+    state.isModified = true;
+    state.isLive = true;
     state = reducer(state, { type: FETCH_DRAFT_REQUEST, payload: { url: mockDraft.url } });
   });
 
   test('sets draft', () => { expect(state.draft).toEqual({ url: mockDraft.url }); });
   test('sets isLoading', () => { expect(state.isLoading).toBe(true); });
   test('clears isLive', () => { expect(state.isLive).toBe(false); });
+  test('clears isModified', () => { expect(state.isModified).toBe(false); });
 });
 
 describe('a FETCH_DRAFT_SUCCESS action', () => {
-  let state;
   beforeEach(() => {
+    state.isLoading = true;
+    state.isModified = true;
+    state.isLive = false;
     state = reducer(state, { type: FETCH_DRAFT_SUCCESS, payload: { asset: mockDraft } });
   });
 
   test('sets draft', () => { expect(state.draft).toEqual(mockDraft); });
   test('clears isLoading', () => { expect(state.isLoading).toBe(false); });
   test('sets isLive', () => { expect(state.isLive).toBe(true); });
+  test('clears isModified', () => { expect(state.isModified).toBe(false); });
 });
 
 describe('a PATCH_DRAFT action', () => {
-  let state, previousMockDraft, expectedMockDraft;
+  let previousMockDraft, expectedMockDraft;
   beforeEach(() => {
     // shallow copy mock draft
     previousMockDraft = {...mockDraft};
@@ -68,5 +77,13 @@ describe('a PATCH_DRAFT action', () => {
     expectedMockDraft = { ...expectedMockDraft, ...patchFunc(previousMockDraft) };
     state = reducer(state, patchDraft(patchFunc));
     expect(state.draft).toEqual(expectedMockDraft);
+  });
+
+  test('sets isModified', () => {
+    const patch = { foo: 1, bar: 'xxx' };
+    expectedMockDraft = { ...expectedMockDraft, ...patch };
+    expect(state.isModified).toBe(false);
+    state = reducer(state, patchDraft(patch));
+    expect(state.isModified).toBe(true);
   });
 });


### PR DESCRIPTION
This PR implements changes required to address #62.

* 44fd400 adds support for tracking the "modified" state of the current draft entry
* 7f0931f resets the modified state on successful save
* 612afbb adds a new component which monitors the "modified" flag and prevents navigation from in-process entries

Closes #62.