### PR TITLE
HACK: allow searching through "secret" ?q=[...] URL

### DIFF
--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -25,12 +25,23 @@ class AssetList extends Component {
     if(!fetchedAt) {
       // If there is currently a sort query set by the user, use that otherwise update the query
       // with a default sort.
-      const { query, match : {params: {filter}} } = this.props;
+      const { query, match : {params: {filter}}, location } = this.props;
       const { sort: { field } } = query;
+
+      // HACK: allow ?q=<....> to be added to URLs to enable search feature
+      let search = null;
+      if(location.search && (location.search !== '')) {
+        // there was some query string added to the URL, parse it
+        const parsedSearch = new URLSearchParams(location.search);
+
+        // if there is a q=<...> parameter, extract it and set the search
+        if(parsedSearch.has('q')) { search = parsedSearch.get('q'); }
+      }
+
       if(field !== null) {
-        this.getAssetsFilteredByDept(query, filter);
+        this.getAssetsFilteredByDept({ ...query, search }, filter);
       } else {
-        this.getAssetsFilteredByDept({ ...query, ...DEFAULT_QUERY }, filter);
+        this.getAssetsFilteredByDept({ ...query, ...DEFAULT_QUERY, search }, filter);
       }
     }
   }

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -29,6 +29,10 @@ class AssetList extends Component {
       const { sort: { field } } = query;
 
       // HACK: allow ?q=<....> to be added to URLs to enable search feature
+      // This HACK is intended to aid the UX team in searching through entries to evaluate how
+      // people are getting on adding entries. It makes use of URLSearchParams which is not
+      // supported on IE11 and also exposes functionality which has not been fully baked so, once
+      // UX are done, this needs to be removed.
       let search = null;
       if(location.search && (location.search !== '')) {
         // there was some query string added to the URL, parse it


### PR DESCRIPTION
This is a little hack to expose the search functionality by a "hidden" URL parameter on the asset entry list pages.

If "?q=[...]" is appended to the URL, the value is passed to the backend as the "search" parameter.

This is intended a) to make it easy to evaluate the search functionality and b) to aid UX in finding and evaluating usages of the IAR.