### PR TITLE
do not consider fields with blank string to be "complete"

### DIFF
--- a/src/completeness.js
+++ b/src/completeness.js
@@ -4,7 +4,7 @@
  */
 
 // Helper function for determining if a particular asset field has been filled in.
-const isNotEmpty = v => (typeof v !== 'undefined') && v !== null;
+const isNotEmpty = v => (typeof v !== 'undefined') && v !== null && v !== '';
 
 //
 // Functions to determine if an asset (or sections of said) are complete.

--- a/src/completeness.test.js
+++ b/src/completeness.test.js
@@ -72,6 +72,18 @@ describe('an asset', () => {
       delete asset[missingField];
       expectCompleteness(asset, {...ALL_COMPLETE, general: false, all: false});
     });
+
+    describe('with null ' + missingField, () => {
+      const asset = { ...COMPLETE_ASSET };
+      asset[missingField] = null;
+      expectCompleteness(asset, {...ALL_COMPLETE, general: false, all: false});
+    });
+
+    describe('with empty ' + missingField, () => {
+      const asset = { ...COMPLETE_ASSET };
+      asset[missingField] = '';
+      expectCompleteness(asset, {...ALL_COMPLETE, general: false, all: false});
+    });
   });
 });
 


### PR DESCRIPTION
Previously, a field which the backend returned as "" was considered to be filled in by the frontend (but not the backend). Align the frontend and backend's view of a filled in field.

Closes #125.