### PR TITLE
Only get assets if query different from state.

### DIFF
--- a/src/components/CheckIsUser.js
+++ b/src/components/CheckIsUser.js
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Component } from 'react'
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import history from '../history'

--- a/src/components/FetchSelf.js
+++ b/src/components/FetchSelf.js
@@ -1,3 +1,4 @@
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { getSelf } from '../redux/actions/lookupApi';
@@ -9,16 +10,26 @@ import { getSelf } from '../redux/actions/lookupApi';
  *
  * The fetching waits until auth.isLoggedIn becomes true.
  */
-const FetchSelf = ({ isLoggedIn, self, selfLoading, getSelf }) => {
+class FetchSelf extends Component {
 
-  // If we are signed in and we haven't retrieved (and aren't retrieving) the profile -
-  // then retrieve the profile.
-  if (isLoggedIn && !self && !selfLoading) {
-    getSelf();
-  }
+  componentDidMount = () => this.getSelf();
 
-  return null;
-};
+  componentDidUpdate = () => this.getSelf();
+
+  getSelf = () => {
+    // If we are signed in and we haven't retrieved (and aren't retrieving) the profile -
+    // then retrieve the profile.
+    const { isLoggedIn, self, selfLoading, getSelf } = this.props;
+    if (isLoggedIn && !self && !selfLoading) {
+      getSelf();
+    }
+  };
+
+  render = () => {
+    return null;
+  };
+}
+
 
 FetchSelf.propTypes = {
   isLoggedIn: PropTypes.bool.isRequired,

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react'; // used implicitly by JSX
 import PropTypes from 'prop-types';
-import Page from '../containers/Page';
 import { withRouter } from 'react-router'
 import { withStyles } from 'material-ui/styles';
 import { connect } from 'react-redux';
+import _ from "lodash";
+import Page from '../containers/Page';
 import { getAssets, Direction } from '../redux/actions/assetRegisterApi';
 import { AssetListHeader, AssetTable, GetMoreAssets } from "../components";
 
@@ -15,60 +16,62 @@ export const DEFAULT_QUERY = {
 class AssetList extends Component {
 
   componentDidMount() {
-    const { fetchedAt } = this.props;
+    // Fetch an asset list. If there is currently a sort query set by the user, use that.
+    // Otherwise update the query with a default sort.
+    const { query, match : {params: {filter: department}}, location } = this.props;
+    const { sort: { field } } = query;
 
-    // Fetch an asset list if one has not already been fetched. We detect an existing fetch by
-    // looking at the "fetchedAt" value on the asset list which should be non-NULL if a fetch
-    // happened.
-    if(!fetchedAt) {
-      // If there is currently a sort query set by the user, use that otherwise update the query
-      // with a default sort.
-      const { query, match : {params: {filter}}, location } = this.props;
-      const { sort: { field } } = query;
+    // HACK: allow ?q=<....> to be added to URLs to enable search feature
+    // This HACK is intended to aid the UX team in searching through entries to evaluate how
+    // people are getting on adding entries. It makes use of URLSearchParams which is not
+    // supported on IE11 and also exposes functionality which has not been fully baked so, once
+    // UX are done, this needs to be removed.
+    let search = null;
+    if(location.search && (location.search !== '')) {
+      // there was some query string added to the URL, parse it
+      const parsedSearch = new URLSearchParams(location.search);
 
-      // HACK: allow ?q=<....> to be added to URLs to enable search feature
-      // This HACK is intended to aid the UX team in searching through entries to evaluate how
-      // people are getting on adding entries. It makes use of URLSearchParams which is not
-      // supported on IE11 and also exposes functionality which has not been fully baked so, once
-      // UX are done, this needs to be removed.
-      let search = null;
-      if(location.search && (location.search !== '')) {
-        // there was some query string added to the URL, parse it
-        const parsedSearch = new URLSearchParams(location.search);
-
-        // if there is a q=<...> parameter, extract it and set the search
-        if(parsedSearch.has('q')) { search = parsedSearch.get('q'); }
-      }
-
-      if(field !== null) {
-        this.getAssetsFilteredByDept({ ...query, search }, filter);
-      } else {
-        this.getAssetsFilteredByDept({ ...query, ...DEFAULT_QUERY, search }, filter);
-      }
+      // if there is a q=<...> parameter, extract it and set the search
+      if(parsedSearch.has('q')) { search = parsedSearch.get('q'); }
     }
-  }
 
-  /**
-   * If the department filter has changed then re-fetch the list.
-   */
-  componentWillReceiveProps({match : {params: {filter: nextFilter}} }) {
-    const {match : {params: {filter}}, query} = this.props;
-    if (nextFilter !== filter) {
-      this.getAssetsFilteredByDept(query, nextFilter);
-    }
-  }
-
-  /**
-   * Method to apply or remove a department filter to a getAssets() call.
-   */
-  getAssetsFilteredByDept(query, filter = null) {
-    if (filter) {
-      query.filter = {...query.filter, department: filter}
+    if (field !== null) {
+      this.getAssets(query, this.updateQueryWithDept({ ...query, search }));
     } else {
-      delete query.filter.department
+      this.getAssets(query, this.updateQueryWithDept({ ...query, ...DEFAULT_QUERY, search }));
     }
+  }
 
-    this.props.getAssets(query);
+  /**
+   * Apply the current department filter and then (attempt to) re-fetch the list.
+   */
+  componentDidUpdate() {
+    const { query } = this.props;
+    this.getAssets(query, this.updateQueryWithDept(query));
+  }
+
+  /**
+   * Updates the passed query with the current department defined in the url.
+   * Return's an updated copy.
+   */
+  updateQueryWithDept(query) {
+    const { match : { params: { filter: department } } } = this.props;
+    if (department) {
+      return { ...query, filter: { ...query.filter, department: department } }
+    } else {
+      // deletes the department field
+      const {department, ...filter} = query.filter;
+      return { ...query, filter: filter };
+    }
+  }
+
+  /**
+   * Call getAssets() if the new query doesn't match the old one.
+   */
+  getAssets(oldQuery, newQuery) {
+    if (!_.isEqual(oldQuery, newQuery)) {
+      this.props.getAssets(newQuery);
+    }
   }
 
   render() {

--- a/src/containers/AssetList.js
+++ b/src/containers/AssetList.js
@@ -18,7 +18,7 @@ class AssetList extends Component {
   componentDidMount() {
     // Fetch an asset list. If there is currently a sort query set by the user, use that.
     // Otherwise update the query with a default sort.
-    const { query, match : {params: {filter: department}}, location } = this.props;
+    const { query, location } = this.props;
     const { sort: { field } } = query;
 
     // HACK: allow ?q=<....> to be added to URLs to enable search feature
@@ -35,11 +35,10 @@ class AssetList extends Component {
       if(parsedSearch.has('q')) { search = parsedSearch.get('q'); }
     }
 
-    if (field !== null) {
-      this.getAssets(query, this.updateQueryWithDept({ ...query, search }));
-    } else {
-      this.getAssets(query, this.updateQueryWithDept({ ...query, ...DEFAULT_QUERY, search }));
-    }
+    const newQuery = this.updateQueryWithDept({
+      ...query, ...(field === null ? DEFAULT_QUERY : {}), search
+    });
+    this.getAssets(query, newQuery);
   }
 
   /**
@@ -55,9 +54,9 @@ class AssetList extends Component {
    * Return's an updated copy.
    */
   updateQueryWithDept(query) {
-    const { match : { params: { filter: department } } } = this.props;
+    const { match: { params: { filter: department } } } = this.props;
     if (department) {
-      return { ...query, filter: { ...query.filter, department: department } }
+      return { ...query, filter: { ...query.filter, department: department } };
     } else {
       // deletes the department field
       const {department, ...filter} = query.filter;

--- a/src/containers/AssetList.test.js
+++ b/src/containers/AssetList.test.js
@@ -36,7 +36,7 @@ test('AssetList can render', () => {
 
 test('AssetList sends a default query if none is set', () => {
   const store = createMockStore(populatedState);
-  render(<AppRoutes />, { store, url: '/assets/', store });
+  render(<AppRoutes />, { store, url: '/assets/' });
 
   // getAssets was called once
   expect(getAssets.mock.calls).toHaveLength(1);
@@ -59,18 +59,10 @@ test('AssetList respects the current query', () => {
   initialState.assets = { ...initialState.assets, query: initialQuery };
 
   const store = createMockStore(initialState);
-  render(<AppRoutes />, { store, url: '/assets/', store });
+  render(<AppRoutes />, { store, url: '/assets', store });
 
-  // getAssets was called once
-  expect(getAssets.mock.calls).toHaveLength(1);
-
-  // get single argument to getAssets
-  const [ [ query ] ] = getAssets.mock.calls;
-
-  // check query matches expected query
-  Object.getOwnPropertyNames(initialQuery).forEach(name => {
-    expect(query[name]).toEqual(initialQuery[name]);
-  });
+  // getAssets never called as the new query matches the old
+  expect(getAssets.mock.calls).toHaveLength(0);
 });
 
 // check that a department filter is set


### PR DESCRIPTION
Refactored AssetList to only get new assets if the new query doesn't match the old (was sort of doing that before but now does it better). Also use componentDidUpdate instead of componentWillReceiveProps to
avoid fetching same assets twice.
closes: #115 
