### PR TITLE
First stab at responsive elements using JSS and theme file

### DIFF
--- a/src/components/AssetListHeader.js
+++ b/src/components/AssetListHeader.js
@@ -15,7 +15,12 @@ const styles = theme => ({
   },
   appBar: {
     backgroundColor: theme.customColors.appBarBackground,
-    paddingLeft: theme.drawerWidth,
+    [theme.breakpoints.down('sm')]: {
+      paddingLeft: theme.drawer.width.xs_sm,
+    },
+    [theme.breakpoints.up('md')]: {
+      paddingLeft: theme.drawer.width.md_xl,
+    },
   },
 });
 

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -9,7 +9,7 @@ import {connect} from "react-redux";
 
 const styles = theme => ({
   drawerHeader: theme.mixins.toolbar,
-  nested: { paddingLeft: theme.spacing.unit * 4 },
+  nested: { paddingLeft: theme.spacing.unit * 5 },
   camLogo: { width: '145px', height: '30px', paddingTop: '10px' },
   tagLine: { fontSize: 12 },
   logoToolbar: { flexDirection:'column', alignItems: 'flex-start', paddingLeft: theme.spacing.unit * 2 },

--- a/src/components/SidebarNavLink.js
+++ b/src/components/SidebarNavLink.js
@@ -6,6 +6,14 @@ import { ListItem, ListItemText } from 'material-ui/List';
 
 const styles = theme => ({
   selected: { background: theme.palette.action.selected },
+  listItem: {
+    [theme.breakpoints.down('sm')]: {
+      fontSize: theme.drawer.listItem.fontSize.xs_sm,
+    },
+    [theme.breakpoints.up('md')]: {
+      fontSize: theme.drawer.listItem.fontSize.md_xl,
+    },
+  }
 });
 
 /**
@@ -34,7 +42,7 @@ const SidebarNavLink = (
 
   return (
     <ListItem button component={component} to={to} className={newClassName} {...rest}>
-      <ListItemText primary={label} />
+      <ListItemText primary={label} className={classes.listItem} disableTypography={true} />
     </ListItem>
   );
 }

--- a/src/containers/Page.js
+++ b/src/containers/Page.js
@@ -18,14 +18,24 @@ const styles = theme => ({
   drawerPaper: {
     position: 'fixed',
     height: '100vh',
-    width: theme.drawerWidth,
+    [theme.breakpoints.down('sm')]: {
+      width: theme.drawer.width.xs_sm,
+    },
+    [theme.breakpoints.up('md')]: {
+      width: theme.drawer.width.md_xl,
+    },
   },
   pageContent: {
     width: '100%',
   },
   pageContentWithSidebar: {
     width: '100%',
-    marginLeft: theme.drawerWidth,
+    [theme.breakpoints.down('sm')]: {
+      marginLeft: theme.drawer.width.xs_sm,
+    },
+    [theme.breakpoints.up('md')]: {
+      marginLeft: theme.drawer.width.md_xl,
+    },
   },
 });
 

--- a/src/style/CustomMaterialTheme.js
+++ b/src/style/CustomMaterialTheme.js
@@ -74,7 +74,18 @@ const theme = createMuiTheme({
       },
     },
   },
-  drawerWidth: 280,
+  drawer: {
+    listItem: {
+      fontSize: {
+        md_xl: '1rem',
+        xs_sm: '0.9rem',
+      },
+    },
+    width: {
+      md_xl: 280,
+      xs_sm: 220,
+    },
+  },
   customMixins: {
     formSection: {
       fontFamily: ['Roboto Mono', 'monospace'],


### PR DESCRIPTION
**Opening a PR here so we can review the architecture. Once agreed I can make my way through various pages/components and make them fluid/responsive.**

For screen-widths of 960px and under, the sidebar should shrink in width and decrease the font-size of the list items.

The theme file holds the values, which are imported via `withStyles` like usual, and the component itself holds the breakpoint logic to apply the styles.

We use the material-ui way of breakpoints, instead of manually applying media queries, for example `@media (min-width: 1px)`. [More info here](https://material-ui-next.com/layout/css-in-js/#theme-breakpoints-up-key-media-query)