### PR TITLE
replace build-time .env configuration with run-time config.js file

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,12 @@
-REACT_APP_ENDPOINT_ASSETS=http://localhost:8000/assets/
-REACT_APP_ENDPOINT_LOOKUP=http://localhost:8080/
-REACT_APP_OAUTH_ENDPOINT=http://localhost:4444/oauth2/auth
-REACT_APP_OAUTH_CLIENT=testclient
-REACT_APP_OAUTH_SCOPES="assetregister lookup:anonymous"
-REACT_APP_IAR_USERS_GROUP='uis-iar-users'
+# Add *build time* configuration variables here. These values are baked into the
+# built app and, hence, into the image so only include variables intended to
+# expose differences between dev and production rather than runtime
+# configuration.
+
+# Extra code injected into the <head> of index.html. To override the *runtime*
+# configuration, copy templates/config.in.js to public/config.local.js and
+# override this setting in .env.local:
+#
+#   REACT_APP_INDEX_HTML_HEAD='<script src="/config.local.js"></script>'
+#
+REACT_APP_INDEX_HTML_HEAD=

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ coverage/
 
 # build files
 /build
+
+# local configuration
+public/config.local.js

--- a/README.md
+++ b/README.md
@@ -40,15 +40,30 @@ developer UI at http://localhost:8080/ui.
 
 ## App configuration
 
-Default application configuration is in the `.env file`.
-This can be overridden locally by placing config in a `.env.local` file.
-Note that you must re-run `npm start` for config to take effect.
-Also note all vars names **must** be frefixed with `REACT_APP_`.
-See the [documentation](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-development-environment-variables-in-env) for more information.
+*Build time* configuration is in the [.env](.env) file.
+This can be overridden locally by placing values in a `.env.local` file.
+Note that you must re-run `npm start` for build time configuration to take
+effect. Also note all vars names **must** be frefixed with `REACT_APP_`.  See
+the
+[documentation](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-development-environment-variables-in-env)
+for more information.
 
-Settings which are not included in the [shipped .env file](.env) but which may
-also be of use are:
+*Run time* configuration is specified by setting the
+``window.reactAppConfiguration`` variable. The recommended way to do this is
+outlined in the [.env](.env):
 
-* **REACT_APP_BASENAME**: basename of app if not served from the web server
-    root. Make sure to include trailing and leading slashes.
-* **REACT_APP_OAUTH_REDIRECT**: redirect URL passed to OAuth2 server.
+1. Add the ``REACT_APP_INDEX_HTML_HEAD`` build-time configuration value to
+   ``.env.local`` so that ``<script src="/config.local.js">`` is inserted into
+   the [index.html](public/index.html) file.
+2. Copy the [configuration template](templates/config.in.js) to
+   ``public/config.local.js``.
+3. Add any local configuration to ``public/config.local.js``.
+
+Although you need to re-run ``npm start`` after changing
+``REACT_APP_INDEX_HTML_HEAD``, changes to run-time configuration will
+take effect on the next reload. Both ``.env.local`` and
+``public/config.local.js`` are added to [.gitignore](.gitignore) so that they
+are not inadvertently checked into source control.
+
+**NOTE:** In the test suite, configuration is loaded from [a special
+module](src/test/config.js) since index.html is not parsed when running tests.

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,8 @@
       try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
       catch(e){window.attachEvent("onload", $buo_f)}
     </script>
+
+    %REACT_APP_INDEX_HTML_HEAD%
   </head>
   <body>
     <noscript>

--- a/src/AssetDetail/containers/FetchAsset.js
+++ b/src/AssetDetail/containers/FetchAsset.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
-import { getAsset } from '../../redux/actions/assetRegisterApi';
+import { getAsset, ENDPOINT_ASSETS } from '../../redux/actions/assetRegisterApi';
 
 /**
  * A component which examines the current matched route and fetches the matching asset. Takes a
@@ -52,7 +52,7 @@ const mapStateToProps = (state, ownProps) => {
   const { match: { params: { assetId } } } = ownProps;
 
   // Construct asset URL and try to retrieve asset record object from state.
-  const url = process.env.REACT_APP_ENDPOINT_ASSETS + assetId + '/';
+  const url = ENDPOINT_ASSETS + assetId + '/';
 
   return {
     url: url,

--- a/src/AssetDetail/containers/FetchOrCreateDraft.js
+++ b/src/AssetDetail/containers/FetchOrCreateDraft.js
@@ -7,6 +7,7 @@ import { withDraft } from '../../draft';
 
 import { WaitForSelf } from '../../waiting';
 
+import { ENDPOINT_ASSETS } from '../../redux/actions/assetRegisterApi';
 import { DEFAULT_ASSET } from '../../redux/actions/editAsset';
 
 /**
@@ -41,7 +42,7 @@ class FetchOrCreateDraft extends Component {
 
     // construct URL for asset or null if we're creating a new asset. We know if we're creating
     // new asset because the assetId will be undefined.
-    const url = assetId ? process.env.REACT_APP_ENDPOINT_ASSETS + assetId + '/' : null;
+    const url = assetId ? ENDPOINT_ASSETS + assetId + '/' : null;
 
     // pass this URL (or null) to fetchOrCreateDraft to populate a new draft
     fetchOrCreateDraft(url, template);

--- a/src/AssetDetail/presentational/AssetView.test.js
+++ b/src/AssetDetail/presentational/AssetView.test.js
@@ -7,12 +7,14 @@ import AssetPage from './AssetPage';
 import ViewHeader from './ViewHeader';
 import ViewBody from './ViewBody';
 
+import { ENDPOINT_ASSETS } from '../../redux/actions/assetRegisterApi';
+
 describe('AssetView', () => {
   describe('with assets loaded', () => {
     let store, testInstance, asset, url;
     beforeEach(() => {
       store = createMockStore(populatedState);
-      url = process.env.REACT_APP_ENDPOINT_ASSETS + 'xxx/';
+      url = ENDPOINT_ASSETS + 'xxx/';
       asset = populatedState.assets.assetsByUrl.get(url).asset;
       expect(asset).toBeDefined();
       testInstance = render(<AppRoutes />, { url: '/asset/xxx', store });

--- a/src/components/CheckIsUser.js
+++ b/src/components/CheckIsUser.js
@@ -4,11 +4,13 @@ import { connect } from 'react-redux';
 import history from '../history'
 import { WaitForSelf } from "../waiting";
 
+import config from '../config';
+
 export const NOT_A_USER_PATH = '/no_permission';
 
 /**
  * A component which checks that the user has been configured as a user of the application.
- * Specifically it checks if the user is in the REACT_APP_IAR_USERS_GROUP. If they aren't,
+ * Specifically it checks if the user is in the config.iarUsersLookupGroup. If they aren't,
  * the user is redirected to a page explaining why they can't access the system.
  */
 class UnconnectedCheckIsUser extends Component {
@@ -32,7 +34,7 @@ UnconnectedCheckIsUser.propTypes = {
 
 const mapStateToProps = ({ lookupApi: { self: { groups } } }) => ({
   inIARUsersGroup :
-    !!groups.find((group) => (group.name === process.env.REACT_APP_IAR_USERS_GROUP))
+    !!groups.find((group) => (group.name === config.iarUsersLookupGroup))
 });
 
 const CheckIsUser = connect(mapStateToProps)(UnconnectedCheckIsUser);

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,47 @@
+/**
+ * A module which exports the runtime configuration for the application.
+ *
+ * This should be set on the window object as reactAppConfiguration.
+ */
+import testConfig from './test/config';
+
+// This is the *default* configuration. Settings in config.js override this.
+const defaultConfig = {
+  // Base URL of this web application.
+  basename: '/',
+
+  // OAuth2 scopes requested for our access token.
+  oauth2Scopes: 'assetregister lookup:anonymous',
+
+  // OAuth2 client configuration.
+  oauth2ClientId: 'testclient',
+
+  // The default for the optional oauth2RedirectUrl configuration value is computed below since
+  // it depends on the final value of basename.
+
+  // Size of popup window used for OAuth2 implicit flow.
+  oauth2PopupWidth: 640,
+  oauth2PopupHeight: 512,
+
+  // Lookup group used to gate access to the IAR.
+  iarUsersLookupGroup: 'uis-iar-users',
+
+  // API endpoints.
+  assetRegisterEndpoint: 'http://localhost:8000/',
+  lookupEndpoint: 'http://localhost:8080/',
+  oauth2AuthEndpoint: 'http://localhost:4444/oauth2/auth',
+};
+
+// When running in the test suite, we actually want to make use of the test configuration.
+const config = {
+  ...defaultConfig,
+  ...(process.env.NODE_ENV === 'test') ? testConfig : window.reactAppConfiguration,
+};
+
+// If it hasn't previously been set, set the rdirect URL for OAuth2 implicit flow. We set it here
+// because "basename" may have been overridden by the reactAppConfiguration object.
+if(!config.oauth2RedirectUrl) {
+  config.oauth2RedirectUrl = window.location.origin + config.basename + 'oauth2-callback';
+}
+
+export default config;

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -12,9 +12,11 @@ import AppRoutes from './AppRoutes';
 import theme from '../style/CustomMaterialTheme';
 import '../style/App.css';
 
-// Allow configuration of basename via REACT_APP_BASENAME environment variable. Defaults to "/".
+import config from '../config';
+
+// Allow configuration of basename via config.basename variable. Defaults to "/".
 // Make sure to have leading *and* trailing slashes if you configure this setting.
-const basename = process.env.REACT_APP_BASENAME || '/';
+const basename = config.basename;
 
 /*
   IAR main app component.

--- a/src/containers/AppRoutes.test.js
+++ b/src/containers/AppRoutes.test.js
@@ -8,6 +8,8 @@ import { populatedState } from '../test/fixtures';
 import AppRoutes from './AppRoutes';
 import NotFoundPage from './NotFoundPage';
 
+import { ENDPOINT_ASSETS } from '../redux/actions/assetRegisterApi';
+
 const appBarTitle = testInstance => (
   testInstance.findByType(AppBar).findByType(Typography).props.children
 );
@@ -71,7 +73,7 @@ test('can render /asset/', () => {
 test('can render /asset/e20f4cd4-9f97-4829-8178-476c7a67eb97', () => {
 
   const assetsByUrl = new Map([[
-    process.env.REACT_APP_ENDPOINT_ASSETS + 'e20f4cd4-9f97-4829-8178-476c7a67eb97/', {
+    ENDPOINT_ASSETS + 'e20f4cd4-9f97-4829-8178-476c7a67eb97/', {
       asset: {name: 'Super Secret Medical Data'}
     }
   ]]);

--- a/src/redux/actions/assetRegisterApi.js
+++ b/src/redux/actions/assetRegisterApi.js
@@ -1,6 +1,7 @@
 import { RSAA } from 'redux-api-middleware';
+import config from '../../config';
 
-const ASSETS_URL = process.env.REACT_APP_ENDPOINT_ASSETS;
+export const ENDPOINT_ASSETS = config.assetRegisterEndpoint + 'assets/';
 
 export const ASSETS_LIST_REQUEST = 'ASSETS_LIST_REQUEST';
 export const ASSETS_LIST_SUCCESS = 'ASSETS_LIST_SUCCESS';
@@ -104,7 +105,7 @@ export const getAssets = (unsanitisedQuery = {}) => {
   }
 
   // Build the URL
-  const url = ASSETS_URL + (
+  const url = ENDPOINT_ASSETS + (
     (queryParts.length > 0)
     ? ('?' + queryParts.map(([key, value]) => key + '=' + encodeURIComponent(value)).join('&'))
     : ''
@@ -203,15 +204,15 @@ export const putAsset = asset => ({
  */
 export const postAsset = asset => ({
   [RSAA]: {
-    endpoint: ASSETS_URL,
+    endpoint: ENDPOINT_ASSETS,
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify(asset),
     types: [
-      { type: ASSET_POST_REQUEST, meta: { url: ASSETS_URL , asset } },
+      { type: ASSET_POST_REQUEST, meta: { url: ENDPOINT_ASSETS , asset } },
         // body added for testing TODO: find a better way of checking body
-      { type: ASSET_POST_SUCCESS, meta: { url: ASSETS_URL } },
-      { type: ASSET_POST_FAILURE, meta: { url: ASSETS_URL } },
+      { type: ASSET_POST_SUCCESS, meta: { url: ENDPOINT_ASSETS } },
+      { type: ASSET_POST_FAILURE, meta: { url: ENDPOINT_ASSETS } },
     ]
   }
 });

--- a/src/redux/actions/assetRegisterApi.test.js
+++ b/src/redux/actions/assetRegisterApi.test.js
@@ -1,6 +1,7 @@
 import { isRSAA, RSAA } from 'redux-api-middleware';
 import {
   getAssets, Direction, putAsset, postAsset,
+  ENDPOINT_ASSETS,
   ASSET_GET_SUCCESS,
   ASSET_PUT_SUCCESS, ASSET_PUT_FAILURE,
   ASSET_POST_SUCCESS, ASSET_POST_FAILURE,
@@ -12,7 +13,7 @@ import splitUrl from "../../test/splitUrl";
 const getAssetsAndParse = (...args) => {
   const { [RSAA]: { endpoint = '' } } = getAssets(...args);
   const { baseUrl, queryItems } = splitUrl(endpoint);
-  expect(baseUrl).toBe(process.env.REACT_APP_ENDPOINT_ASSETS);
+  expect(baseUrl).toBe(ENDPOINT_ASSETS);
   return queryItems;
 };
 

--- a/src/redux/actions/auth.js
+++ b/src/redux/actions/auth.js
@@ -7,28 +7,24 @@
  */
 import { login as implicitLogin, logout as implicitLogout } from 'redux-implicit-oauth2';
 import history from '../../history'
-
-// construct the OAuth2 redirect URL if not specified.
-const basename = process.env.REACT_APP_BASENAME || '/';
-const redirect =
-  process.env.REACT_APP_OAUTH_REDIRECT || window.location.origin + basename + 'oauth2-callback';
+import config from '../../config';
 
 /**
  * OAuth2 credentials configuration for the IAR frontend application.
  */
-const config = {
-  url: process.env.REACT_APP_OAUTH_ENDPOINT,
-  client: process.env.REACT_APP_OAUTH_CLIENT,
-  redirect: redirect,
-  scope: process.env.REACT_APP_OAUTH_SCOPES,
-  width: 640, // Width (in pixels) of login popup window.
-  height: 512 // Height (in pixels) of login popup window.
+const oauth2Config = {
+  url: config.oauth2AuthEndpoint,
+  client: config.oauth2ClientId,
+  redirect: config.oauth2RedirectUrl,
+  scope: config.oauth2Scopes,
+  width: config.oauth2PopupWidth, // Width (in pixels) of login popup window.
+  height: config.oauth2PopupHeight, // Height (in pixels) of login popup window.
 };
 
 /**
  * Initialise login to application.
  */
-export const login = () => implicitLogin(config);
+export const login = () => implicitLogin(oauth2Config);
 
 /**
  * Log out from the application and redirect to "/".

--- a/src/redux/actions/lookupApi.js
+++ b/src/redux/actions/lookupApi.js
@@ -1,4 +1,5 @@
 import { RSAA } from 'redux-api-middleware';
+import config from '../../config';
 
 export const PEOPLE_LIST_REQUEST = 'PEOPLE_LIST_REQUEST';
 export const PEOPLE_LIST_SUCCESS = 'PEOPLE_LIST_SUCCESS';
@@ -17,8 +18,8 @@ export const INSTITUTIONS_LIST_REQUEST = 'INSTITUTIONS_LIST_REQUEST';
 export const INSTITUTIONS_LIST_SUCCESS = 'INSTITUTIONS_LIST_SUCCESS';
 export const INSTITUTIONS_LIST_FAILURE = 'INSTITUTIONS_LIST_FAILURE';
 
-export const ENDPOINT_PEOPLE = process.env.REACT_APP_ENDPOINT_LOOKUP + 'people';
-export const ENDPOINT_INSTUTITIONS = process.env.REACT_APP_ENDPOINT_LOOKUP + 'institutions';
+export const ENDPOINT_PEOPLE = config.lookupEndpoint + 'people';
+export const ENDPOINT_INSTUTITIONS = config.lookupEndpoint + 'institutions';
 
 /**
  * Fetch a list of people.

--- a/src/test/config.js
+++ b/src/test/config.js
@@ -1,0 +1,17 @@
+/**
+ * Module providing mock configuration for the test suite. Exports an object for the test suite
+ * which stands in for the reactAppConfiguration object provided by config.js. Default calues for
+ * configuration settings are still used if not overridden here.
+ */
+
+const config = {
+    // API endpoints
+    assetRegisterEndpoint: 'http://assetregister.invalid/',
+    lookupEndpoint: 'http://lookup.invalid/',
+    oauth2AuthEndpoint: 'http://oauth2.invalid/auth',
+
+    // OAuth2 client configuration
+    oauth2ClientId: 'test-suite-client',
+};
+
+export default config;

--- a/src/test/fixtures.js
+++ b/src/test/fixtures.js
@@ -1,5 +1,7 @@
 import { Map } from 'immutable';
 import { DEFAULT_INITIAL_STATE as initialState } from '../testutils';
+import { ENDPOINT_ASSETS } from '../redux/actions/assetRegisterApi';
+import config from '../config';
 
 // A state populated with a logged in user and some assets.
 export const populatedState = {
@@ -24,7 +26,7 @@ export const populatedState = {
         { instid: 'INSTB', name: 'Office of B'},
       ],
       groups: [
-        { name: process.env.REACT_APP_IAR_USERS_GROUP }
+        { name: config.iarUsersLookupGroup }
       ]
     },
     selfLoading: false,
@@ -33,11 +35,11 @@ export const populatedState = {
     ...initialState.assets,
     assetsByUrl: new Map([
       [
-        process.env.REACT_APP_ENDPOINT_ASSETS + 'xxx/',
-        { asset: { url: process.env.REACT_APP_ENDPOINT_ASSETS + 'xxx/', department: 'INSTB' }, fetchedAt: new Date() }],
+        ENDPOINT_ASSETS + 'xxx/',
+        { asset: { url: ENDPOINT_ASSETS + 'xxx/', department: 'INSTB' }, fetchedAt: new Date() }],
       [
-        process.env.REACT_APP_ENDPOINT_ASSETS + 'yyy/',
-        { asset: { url: process.env.REACT_APP_ENDPOINT_ASSETS + 'yyy/', department: 'INSTC' }, fetchedAt: new Date() }],
+        ENDPOINT_ASSETS + 'yyy/',
+        { asset: { url: ENDPOINT_ASSETS + 'yyy/', department: 'INSTC' }, fetchedAt: new Date() }],
     ])
   }
 };

--- a/src/test/mocks.js
+++ b/src/test/mocks.js
@@ -8,7 +8,3 @@ import React from 'react';
 // GetMoreAssets needs mocking here because of the VisibilitySensor component it uses which requires
 // more of the DOM to be present than is provided by our test suite.
 jest.mock('../components/GetMoreAssets', () => () => <div />);
-
-// Mock configuration for endpoints
-process.env.REACT_APP_ENDPOINT_ASSETS = 'http://iar-backend.invalid/assets/';
-process.env.REACT_APP_ENDPOINT_LOOKUP = 'http://lookupproxy.invalid/';

--- a/templates/config.in.js
+++ b/templates/config.in.js
@@ -1,0 +1,13 @@
+// Template runtime configuration for the application which override the defaults in src/config.js.
+// This file is not transpiled and so must use a version of JavaScript understood by all target
+// browsers.
+//
+// We user Object.assign() here so that we *update* the reactAppConfiguration variable, rather than
+// *replace* it. This allows JavaScript before us to provide additional/default values.
+window.reactAppConfiguration = Object.assign(
+  {},
+  window.reactAppConfiguration ? window.reactAppConfiguration : {},
+  {
+    // Put local configuration here.
+  }
+);


### PR DESCRIPTION
Application configuration via .env files had the advantage that the configuration was baked into the production app at npm build time. This was also a disadvantage since some configuration differes between releases (test, production, etc) and we'd like to use the same application image to serve them if possible.

Move existing uses of the REACT_APP_... environment variables over to a new configuration object which is initialised at runtime and may be overridden both locally in development and in production by adding a line to index.html. See the README.md changes for more details.

For the test suite, there is no browser and index.html is not loaded. In this case the configuration is loaded from the default export of the src/test/config.js module instead.

To use the configuration mechanism, import the src/config.js module.  This module's default export is the application configuration and the implementation of the module takes care of returning the global variable from window or the test configuration as appropriate.