### PR TITLE
disable Save Entry button if department is blank

### DIFF
--- a/src/AssetDetail/containers/SaveDraftButton.js
+++ b/src/AssetDetail/containers/SaveDraftButton.js
@@ -50,7 +50,12 @@ SaveDraftButton.propTypes = {
 
 export default withRouter(
   connect(null, { snackbarOpen })(
-    withDraft((draftObject, ownProps, { saveDraft }) => ({ saveDraft }))(
+    withDraft(
+      ({ draft }, ownProps, { saveDraft }) => ({
+        disabled: (!draft) || (!draft.department) || (draft.department === ''),
+        saveDraft,
+      })
+    )(
       SaveDraftButton
     )
   )


### PR DESCRIPTION
If a user with two or more institutions creates a new entry, the "institution" field is initially blank. Trying to save the entry will result in a HTTP 400 error.

The underlying reason is that the department field must not be blank.

Ensure that the Save Entry button is disabled until the department field is non-blank.