### PR TITLE
only try to fetch institutions list and "self" once

### DIFF
--- a/src/components/FetchLookupInstitutions.js
+++ b/src/components/FetchLookupInstitutions.js
@@ -9,26 +9,28 @@ import { listInstitutions } from '../redux/actions/lookupApi';
  *
  * The fetching waits until auth.isLoggedIn becomes true.
  */
-const FetchLookupInstitutions = ({ isLoggedIn, institutionsWereFetched, listInstitutions }) => {
+const FetchLookupInstitutions = ({ shouldFetch, listInstitutions }) => {
   // The component renders to null but, as a side-effect of rendering, it will cause a fetch of
   // institutions is they have not currently been fetched and isLoggedIn becomes true.
 
-  if(isLoggedIn && !institutionsWereFetched) { listInstitutions(); }
+  if(shouldFetch) { listInstitutions(); }
 
   return null;
 }
 
 FetchLookupInstitutions.propTypes = {
-  isLoggedIn: PropTypes.bool.isRequired,
-  institutionsWereFetched: PropTypes.bool.isRequired,
+  shouldFetch: PropTypes.bool.isRequired,
   listInstitutions: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = ({ auth: { isLoggedIn }, lookupApi: { institutions } }) => ({
-  isLoggedIn,
-  // we break this out as a separate prop so that any extra information which gets added to the
-  // institutions state in future does not cause unnecessary re-renders.
-  institutionsWereFetched: institutions.fetchedAt !== null,
+  // We should try to fetch the institutions list if:
+  // 1) We're actually logged in, and
+  // 2) A request is not currently in flight, and
+  // 3) We have not yet fetched a list, and
+  // 4) We have not yet *requested* a list.
+  shouldFetch:
+    isLoggedIn && !institutions.isLoading && !institutions.fetchedAt && !institutions.requestedAt
 });
 
 const mapDispatchToProps = { listInstitutions };

--- a/src/components/FetchSelf.js
+++ b/src/components/FetchSelf.js
@@ -19,8 +19,8 @@ class FetchSelf extends Component {
   getSelf = () => {
     // If we are signed in and we haven't retrieved (and aren't retrieving) the profile -
     // then retrieve the profile.
-    const { isLoggedIn, self, selfLoading, getSelf } = this.props;
-    if (isLoggedIn && !self && !selfLoading) {
+    const { shouldFetch, getSelf } = this.props;
+    if (shouldFetch) {
       getSelf();
     }
   };
@@ -32,14 +32,19 @@ class FetchSelf extends Component {
 
 
 FetchSelf.propTypes = {
-  isLoggedIn: PropTypes.bool.isRequired,
-  self: PropTypes.object,
-  selfLoading: PropTypes.bool.isRequired,
+  shouldFetch: PropTypes.bool.isRequired,
   getSelf: PropTypes.func.isRequired,
 };
 
-const mapStateToProps = ({ auth: { isLoggedIn }, lookupApi: { self, selfLoading } }) => ({
-  isLoggedIn, self, selfLoading
+const mapStateToProps = (
+  { auth: { isLoggedIn }, lookupApi: { self, selfLoading, selfRequestedAt } }
+) => ({
+  // The logic here is that we should only try to fetch the current user's profile if:
+  // 1) They are logged in, and
+  // 2) The profile is not currently fetched, and
+  // 3) There is not currently a request in flight, and
+  // 4) There had not previously been a request which failed
+  shouldFetch: isLoggedIn && !self && !selfLoading && !selfRequestedAt
 });
 
 const mapDispatchToProps = { getSelf };

--- a/src/redux/reducers/lookupApi.js
+++ b/src/redux/reducers/lookupApi.js
@@ -59,16 +59,19 @@ export default (state = initialState, action) => {
 
     case PEOPLE_GET_SELF_REQUEST:
       // use an empty object is indicate loading
-      return { ...state, selfLoading: true };
+      return { ...state, selfLoading: true, selfRequestedAt: new Date() };
 
     case PEOPLE_GET_SELF_RESET:
-    case PEOPLE_GET_SELF_FAILURE:
-      // reset self in case of reset and failure.
-      return { ...state, self: null, selfLoading: false };
+      // reset self in case of reset
+      return { ...state, self: null, selfLoading: false, selfRequestedAt: null };
 
     case PEOPLE_GET_SELF_SUCCESS:
       // Add the person to the peopleByCrsid map
       return { ...state, self: action.payload, selfLoading: false};
+
+    case PEOPLE_GET_SELF_FAILURE:
+      // reset self in case of failure
+      return { ...state, self: null, selfLoading: false };
 
     case INSTITUTIONS_LIST_REQUEST:
       // An institution request is in flight.

--- a/src/redux/reducers/lookupApi.js
+++ b/src/redux/reducers/lookupApi.js
@@ -22,6 +22,9 @@ export const initialState = {
   // the authenticated user's profile
   self: null,
 
+  // If non-NULL, a JS Date object indicating when the user's profile was last requested.
+  selfRequestedAt: null,
+
   // whether or not the authenticated user's profile is being loaded
   selfLoading: false,
 

--- a/src/redux/reducers/lookupApi.test.js
+++ b/src/redux/reducers/lookupApi.test.js
@@ -95,6 +95,16 @@ test("the selfLoading flag is set", () => {
   expect(nextState.selfLoading).toBe(true);
 });
 
+// check that the selfLoading flag is set when the self is requested
+test("the selfRequestedAt flag is set", () => {
+
+  const nextState = reducer(initialState, {type: PEOPLE_GET_SELF_REQUEST});
+
+  expect(nextState.self).toBeNull();
+  expect(nextState.selfRequestedAt).toBeDefined()
+  expect(nextState.selfRequestedAt).not.toBeNull();
+});
+
 // check that the authenticated user's profile is set in self
 test("the authenticated user's profile is set in self", () => {
 

--- a/src/redux/reducers/lookupApi.test.js
+++ b/src/redux/reducers/lookupApi.test.js
@@ -3,7 +3,8 @@ import { Map } from 'immutable';
 import reducer, { initialState } from './lookupApi';
 import {
   PEOPLE_GET_SELF_REQUEST, PEOPLE_GET_SELF_SUCCESS, PEOPLE_GET_SUCCESS,
-  PEOPLE_LIST_SUCCESS, INSTITUTIONS_LIST_SUCCESS
+  PEOPLE_LIST_SUCCESS,
+  INSTITUTIONS_LIST_REQUEST, INSTITUTIONS_LIST_SUCCESS, INSTITUTIONS_LIST_FAILURE
 } from '../actions/lookupApi';
 
 // test that the state is correctly initialised.
@@ -119,7 +120,10 @@ test("the authenticated user's profile is set in self", () => {
 });
 
 test('institutions are copied from institution list success action', () => {
-  const initialState = reducer(undefined, { type: 'not-an-action' });
+  const initialState = reducer(undefined, { type: INSTITUTIONS_LIST_REQUEST });
+  expect(initialState.institutions.requestedAt).toBeDefined();
+  expect(initialState.institutions.requestedAt).not.toBeNull();
+  expect(initialState.institutions.isLoading).toBe(true);
   expect(initialState.institutions.fetchedAt).toBeNull();
   expect(initialState.institutions.byInstid.get('AAA')).toBeUndefined();
 
@@ -133,9 +137,51 @@ test('institutions are copied from institution list success action', () => {
 
   const nextState = reducer(initialState, action);
 
+  expect(nextState.institutions.requestedAt).toBeDefined();
+  expect(nextState.institutions.requestedAt).not.toBeNull();
+  expect(nextState.institutions.isLoading).toBe(false);
+  expect(nextState.institutions.fetchedAt).toBeDefined();
   expect(nextState.institutions.fetchedAt).not.toBeNull();
+  expect(nextState.institutions.errorPayload).toBeNull();
   expect(nextState.institutions.byInstid.get('AAA')).toEqual({ instid: 'AAA', name: 'Dept of A' });
   expect(nextState.institutions.byInstid.get('BBB')).toEqual({ instid: 'BBB', name: 'Dept of B' });
+});
+
+test('requestedAt is updated when institutions are requested', () => {
+  const initialState = reducer(undefined, { type: 'not-an-action' });
+  expect(initialState.institutions.fetchedAt).toBeNull();
+  expect(initialState.institutions.byInstid.get('AAA')).toBeUndefined();
+
+  const action = {
+    type: INSTITUTIONS_LIST_REQUEST,
+  };
+
+  const nextState = reducer(initialState, action);
+
+  expect(nextState.institutions.requestedAt).toBeDefined();
+  expect(nextState.institutions.requestedAt).not.toBeNull();
+});
+
+test('failure is logged on institution list failure action', () => {
+  const initialState = reducer(undefined, { type: INSTITUTIONS_LIST_REQUEST });
+  expect(initialState.institutions.requestedAt).toBeDefined();
+  expect(initialState.institutions.requestedAt).not.toBeNull();
+  expect(initialState.institutions.isLoading).toBe(true);
+  expect(initialState.institutions.fetchedAt).toBeNull();
+  expect(initialState.institutions.byInstid.get('AAA')).toBeUndefined();
+
+  const action = {
+    type: INSTITUTIONS_LIST_FAILURE,
+    payload: { error: 'some message' },
+  };
+
+  const nextState = reducer(initialState, action);
+
+  expect(nextState.institutions.requestedAt).toBeDefined();
+  expect(nextState.institutions.requestedAt).not.toBeNull();
+  expect(nextState.institutions.isLoading).toBe(false);
+  expect(nextState.institutions.fetchedAt).toBeNull();
+  expect(nextState.institutions.errorPayload).toEqual(action.payload);
 });
 
 test('byInstid is an immutable map after update', () => {


### PR DESCRIPTION
> **Testing notes:** in order to show the problem this PR addresses, one needs to arrange for the lookupproxy to fail. This can be done by downloading a little test script, [corsdevserver.py](https://gist.github.com/rjw57/4a1037d71d9fe42673ed0b2d6c68b929) which can replace the lookupproxy. Run via: ``docker-compose stop lookupproxy && python2 corsdevserver.py``. Without this PR applied, the browser should get stuck in a reload loop for the user's profile.

As noted in #77, if fetching the user's profile fails, we get stuck in a loop where the browser tries again and again, hammering the browser.

For both the user's profile and the list of instututions, record a "requestedAt" date which records when the last request was in flight. We then only try to load the corresponding resource if:

1. There is not a resource loaded, and
2. There is not a request in flight, *and*
3. There had not been a request previously.

Number 3 was lacking from our logic before meaning that there was no "memory" of having tried to request the user's profile or list of institutions.

Closes #77