### PR TITLE
Provide indication when loading asset entries into the list

### DIFF
--- a/src/components/AssetTableHeader.js
+++ b/src/components/AssetTableHeader.js
@@ -117,8 +117,8 @@ export const AssetTableHeader = ({ classes }) => (
       <SortCell style={{width: 8*13}} field='updated_at' label='Last edited' />
       <TableCell style={{width: 8*4}}>&nbsp;</TableCell>
     </TableRow>
-    <TableRow className={classes.loadingRow}>
-      <TableCell colSpan={6} className={classes.loadingCell}>
+    <TableRow className={classes.loadingContainerRow}>
+      <TableCell colSpan={6} className={classes.loadingContainerCell}>
         <div className={classes.loadingContainer}>
           <LoadingIndicator />
         </div>
@@ -132,11 +132,11 @@ AssetTableHeader.propTypes = {
 };
 
 const styles = theme => ({
-  loadingCell: {
+  loadingContainerCell: {
     height: 0, position: 'relative', margin: 0, padding: 0, border: 'none',
   },
 
-  loadingRow: {
+  loadingContainerRow: {
     height: 0, margin: 0, padding: 0, border: 'none',
   },
 

--- a/src/components/AssetTableHeader.js
+++ b/src/components/AssetTableHeader.js
@@ -6,8 +6,7 @@ import { getAssets, Direction } from '../redux/actions/assetRegisterApi';
 import { TableRow, TableCell, TableSortLabel, TableHead } from 'material-ui/Table';
 import Tooltip from 'material-ui/Tooltip';
 import HelpOutlineIcon from 'material-ui-icons/HelpOutline';
-import { LinearProgress } from 'material-ui/Progress';
-import Fade from 'material-ui/transitions/Fade';
+import LoadingIndicator from '../containers/LoadingIndicator';
 
 // A map from sort directions to values for the "direction" prop of TableSortLabel.
 const directionDescriptions = new Map([
@@ -84,14 +83,6 @@ const TooltipText = withStyles(tooltipTextStyle)(({ title, children, classes }) 
     </div>
   </Tooltip>
 ));
-
-// An indeterminate linear progress indicator which is ownly shown when there is an asset list
-// request in flight.
-const LoadingIndicator = connect(({ assets: { isLoading } }) => ({ isLoading }))(
-  ({ isLoading }) => (
-    <Fade in={isLoading}><LinearProgress /></Fade>
-  )
-);
 
 /**
  * A component which provides the header row for the asset table. Heading titles can be used to

--- a/src/components/AssetTableHeader.js
+++ b/src/components/AssetTableHeader.js
@@ -6,6 +6,8 @@ import { getAssets, Direction } from '../redux/actions/assetRegisterApi';
 import { TableRow, TableCell, TableSortLabel, TableHead } from 'material-ui/Table';
 import Tooltip from 'material-ui/Tooltip';
 import HelpOutlineIcon from 'material-ui-icons/HelpOutline';
+import { LinearProgress } from 'material-ui/Progress';
+import Fade from 'material-ui/transitions/Fade';
 
 // A map from sort directions to values for the "direction" prop of TableSortLabel.
 const directionDescriptions = new Map([
@@ -83,12 +85,20 @@ const TooltipText = withStyles(tooltipTextStyle)(({ title, children, classes }) 
   </Tooltip>
 ));
 
+// An indeterminate linear progress indicator which is ownly shown when there is an asset list
+// request in flight.
+const LoadingIndicator = connect(({ assets: { isLoading } }) => ({ isLoading }))(
+  ({ isLoading }) => (
+    <Fade in={isLoading}><LinearProgress /></Fade>
+  )
+);
+
 /**
  * A component which provides the header row for the asset table. Heading titles can be used to
  * change sort order.
  *
  */
-export const AssetTableHeader = () => (
+export const AssetTableHeader = ({ classes }) => (
   <TableHead>
     <TableRow>
       <SortCell style={{width: '50%'}} field='name' label='Name' />
@@ -107,7 +117,32 @@ export const AssetTableHeader = () => (
       <SortCell style={{width: 8*13}} field='updated_at' label='Last edited' />
       <TableCell style={{width: 8*4}}>&nbsp;</TableCell>
     </TableRow>
+    <TableRow className={classes.loadingRow}>
+      <TableCell colSpan={6} className={classes.loadingCell}>
+        <div className={classes.loadingContainer}>
+          <LoadingIndicator />
+        </div>
+      </TableCell>
+    </TableRow>
   </TableHead>
 );
 
-export default AssetTableHeader;
+AssetTableHeader.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+const styles = theme => ({
+  loadingCell: {
+    height: 0, position: 'relative', margin: 0, padding: 0, border: 'none',
+  },
+
+  loadingRow: {
+    height: 0, margin: 0, padding: 0, border: 'none',
+  },
+
+  loadingContainer: {
+    position: 'absolute', top: 0, left: 0, width: '100%',
+  },
+});
+
+export default withStyles(styles)(AssetTableHeader);

--- a/src/components/GetMoreAssets.js
+++ b/src/components/GetMoreAssets.js
@@ -8,27 +8,32 @@ import { connect } from 'react-redux';
 /**
  * A component which requests more assets when it becomes visible. The request is only made if the
  * "next" URL is not the same as the "lastRequestedUrl" in the asset state. If there are more
- * assets loading, this component renders as a loading indicator.
+ * asset entries loading *and* those entries will extend the current list, this component renders
+ * as a loading indicator.
  */
-const GetMoreAssets = ({ nextUrl, shouldLoadMore, isLoading, getMoreAssets }) => (
+const GetMoreAssets = ({ nextUrl, shouldLoadMore, isLoading, isExtendingSummaries, getMoreAssets }) => (
   <VisibilitySensor
     active={shouldLoadMore}
     onChange={isVisible => { if(isVisible && shouldLoadMore) { getMoreAssets(nextUrl); } }}
   >
     <div style={{padding: '5px'}}>
-      <CircularProgress style={{visibility: isLoading ? 'visible' : 'hidden' }} />
+      <CircularProgress style={{
+        visibility: (isLoading && isExtendingSummaries) ? 'visible' : 'hidden'
+      }} />
     </div>
   </VisibilitySensor>
 );
 
 GetMoreAssets.propTypes = {
   nextUrl: PropTypes.string,
+  isLoading: PropTypes.bool.isRequired,
+  isExtendingSummaries: PropTypes.bool.isRequired,
   shouldLoadMore: PropTypes.bool.isRequired,
   getMoreAssets: PropTypes.func.isRequired,
 }
 
-const mapStateToProps = ({ assets: { url, next: nextUrl, isLoading } }) => ({
-  nextUrl, isLoading,
+const mapStateToProps = ({ assets: { url, next: nextUrl, isLoading, isExtendingSummaries } }) => ({
+  nextUrl, isLoading, isExtendingSummaries,
 
   // The logic here is that we should only request more assets when the last loaded URL is not the
   // current next URL and we don't currently have a request in flight.

--- a/src/containers/LoadingIndicator.js
+++ b/src/containers/LoadingIndicator.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import Fade from 'material-ui/transitions/Fade';
+import { LinearProgress } from 'material-ui/Progress';
+
+// An indeterminate linear progress indicator which is ownly shown when there is an asset list
+// request in flight.
+const LoadingIndicator = connect(({ assets: { isLoading } }) => ({ isLoading }))(
+  ({ isLoading }) => (
+    <Fade in={isLoading}><LinearProgress /></Fade>
+  )
+);
+
+export default LoadingIndicator;

--- a/src/redux/actions/assetRegisterApi.js
+++ b/src/redux/actions/assetRegisterApi.js
@@ -126,7 +126,7 @@ export const getAssets = (unsanitisedQuery = {}) => {
 
 /**
  * Request more assets from the API. If URL corresponds to the "next" or "previous" URLs, the list
- * of assets and asset summaries are exteded, otherwise they are replaced.
+ * of assets and asset summaries are extended, otherwise they are replaced.
  */
 export const getMoreAssets = (url) => ({
   [RSAA]: {

--- a/src/redux/reducers/assetRegisterApi.js
+++ b/src/redux/reducers/assetRegisterApi.js
@@ -19,6 +19,11 @@ export const initialState = {
   // they do not modify the next or previous URLs.
   isLoading: false,
 
+  // Boolean indicating if the request currently in flight will extend the summary list as opposed
+  // to replacing it. That is to say, this is true if and only if the requested URL is the next or
+  // previous URL.
+  isExtendingSummaries: false,
+
   // A JavaScript Date object with the last time a fetch resulted in this state being updated.
   fetchedAt: null,
 
@@ -86,7 +91,13 @@ export default (state = initialState, action) => {
     case ASSETS_LIST_REQUEST: {
       // Extract url and query used to fetch this request from action metadata
       const { url, query } = action.meta;
-      return { ...state, ...query ? { query } : { }, url, isLoading: true };
+      return {
+        ...state,
+        ...query ? { query } : { },
+        url,
+        isLoading: true,
+        isExtendingSummaries: (url === state.next) || (url === state.previous)
+      };
     }
 
     case ASSETS_LIST_SUCCESS: {

--- a/src/redux/reducers/assetRegisterApi.test.js
+++ b/src/redux/reducers/assetRegisterApi.test.js
@@ -1,6 +1,6 @@
 import reducer, { initialState } from './assetRegisterApi';
 import {
-  ASSETS_LIST_SUCCESS, ASSETS_DELETE_SUCCESS,
+  ASSETS_LIST_REQUEST, ASSETS_LIST_SUCCESS, ASSETS_DELETE_SUCCESS,
   ASSET_PUT_SUCCESS, ASSET_POST_SUCCESS,
   resetAssets,
 } from '../actions/assetRegisterApi';
@@ -80,4 +80,22 @@ test('Explicit reset of summary state', () => {
   expect(nextState.next).toBeNull();
   expect(nextState.previous).toBeNull();
   expect(nextState.fetchedAt).toBeNull();
+});
+
+test('Requesting "next" URL sets isExtendingSummaries', () => {
+  const action = { type: ASSETS_LIST_REQUEST, meta: { url: stateWithAssets.next } };
+  const nextState = reducer(stateWithAssets, action);
+  expect(nextState.isExtendingSummaries).toBe(true);
+});
+
+test('Requesting "previous" URL sets isExtendingSummaries', () => {
+  const action = { type: ASSETS_LIST_REQUEST, meta: { url: stateWithAssets.previous } };
+  const nextState = reducer(stateWithAssets, action);
+  expect(nextState.isExtendingSummaries).toBe(true);
+});
+
+test('Requesting neither "next" nor "previous" URL clears isExtendingSummaries', () => {
+  const action = { type: ASSETS_LIST_REQUEST, meta: { url: stateWithAssets.next + '/not/next' } };
+  const nextState = reducer(stateWithAssets, action);
+  expect(nextState.isExtendingSummaries).toBe(false);
 });


### PR DESCRIPTION
**Reviewers' note:** this PR is best reviewed commit-wise.

This PR implements some strategies to provide feedback to users when the asset entry table is being refreshed. See #146 for more information. The following three stragegies are employed:

1. When fetching a *new* asset entry list (not simply extending the existing one) the asset list fades out to be replaced with the new one. When extending the asset entry list, the existing behaviour of simply appending to the list is used.
2. When fetching an asset list, a linear progress indicator is added below the asset entry table header. This provides immediate visual feedback to users that a load is happening.
3. To avoid over egging the pudding w.r.t. loading indicators, the circular loading indicator at the bottom of the asset table is shown inly when extending the asset list, not when replacing it.

Closes #146