### PR TITLE
Improve token timeout behaviour

### DIFF
--- a/compose/hydra.env
+++ b/compose/hydra.env
@@ -5,6 +5,10 @@ CONSENT_URL=http://localhost:8090/consent
 ISSUER=http://localhost:4444
 FORCE_ROOT_CLIENT_CREDENTIALS=hydraroot:secret
 
+# Have a short token timeout in development so that any issues with token
+# timeout behaviour have a higher chance of presenting themselves.
+ACCESS_TOKEN_LIFESPAN=5m
+
 # Informative error messages, but dangerous for production
 OAUTH2_SHARE_ERROR_DEBUG=true
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1407,11 +1407,6 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
-    "browser-fingerprint": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/browser-fingerprint/-/browser-fingerprint-0.0.1.tgz",
-      "integrity": "sha1-jfPNyiW/fVs1QtYVRdcwBT/OYEo="
-    },
     "browser-resolve": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
@@ -2747,23 +2742,6 @@
         "cssom": "0.3.2"
       }
     },
-    "cuid": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/cuid/-/cuid-1.3.8.tgz",
-      "integrity": "sha1-S4deCWm612T37AcGz0T1+wgx9rc=",
-      "requires": {
-        "browser-fingerprint": "0.0.1",
-        "core-js": "1.2.7",
-        "node-fingerprint": "0.0.2"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        }
-      }
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -2820,7 +2798,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-diff": {
       "version": "0.3.8",
@@ -7726,11 +7705,6 @@
         "is-stream": "1.1.0"
       }
     },
-    "node-fingerprint": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/node-fingerprint/-/node-fingerprint-0.0.2.tgz",
-      "integrity": "sha1-Mcur63GmeufdWn3AQuUcPHWGhQE="
-    },
     "node-forge": {
       "version": "0.6.33",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.6.33.tgz",
@@ -11209,27 +11183,6 @@
         "babel-plugin-transform-runtime": "6.23.0",
         "babel-runtime": "6.26.0",
         "lodash.isplainobject": "4.0.6"
-      }
-    },
-    "redux-implicit-oauth2": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/redux-implicit-oauth2/-/redux-implicit-oauth2-1.2.1.tgz",
-      "integrity": "sha512-seG96iClXbN07ftjSMGRCyOi6rQRQ6YW24NE9XyXmss9nZbZgjwkFJlcNSOvoH4ue1zLloKPHwgwAV2V1GGEBg==",
-      "requires": {
-        "cuid": "1.3.8",
-        "query-string": "5.0.1"
-      },
-      "dependencies": {
-        "query-string": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.0.1.tgz",
-          "integrity": "sha512-aM+MkQClojlNiKkO09tiN2Fv8jM/L7GWIjG2liWeKljlOdOPNWr+bW3KQ+w5V/uKprpezC7fAsAMsJtJ+2rLKA==",
-          "requires": {
-            "decode-uri-component": "0.2.0",
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
-          }
-        }
       }
     },
     "redux-logger": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2036,6 +2036,15 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
+    "client-oauth2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/client-oauth2/-/client-oauth2-4.2.0.tgz",
+      "integrity": "sha512-houjtiNqIhMuv2RFb49xmNXdmnCUnxrJFbCM3r6kQ+EDiGzKGCdUxMTxdaPgmonAgLa+NIyqKLE6ipAEEtVHEA==",
+      "requires": {
+        "popsicle": "9.2.0",
+        "safe-buffer": "5.1.1"
+      }
+    },
     "clipboard-copy": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-1.4.2.tgz",
@@ -7226,6 +7235,19 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.4.tgz",
+      "integrity": "sha512-0Dab5btKVPhibSalc9QGXb559ED7G7iLjFXBaj9Wq8O3vorueR5K5jaE3hkG6ZQINyhA/JgG6Qk4qdFQjsYV6g=="
+    },
+    "make-error-cause": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
+      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
+      "requires": {
+        "make-error": "1.3.4"
+      }
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -8374,6 +8396,17 @@
       "version": "1.12.9",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.12.9.tgz",
       "integrity": "sha1-DfvC3/lsRRuzMu3Pz6r1ZtMx1bM="
+    },
+    "popsicle": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-9.2.0.tgz",
+      "integrity": "sha512-petRj39w05GvH1WKuGFmzxR9+k+R9E7zX5XWTFee7P/qf88hMuLT7aAO/RsmldpQMtJsWQISkTQlfMRECKlxhw==",
+      "requires": {
+        "concat-stream": "1.6.0",
+        "form-data": "2.3.1",
+        "make-error-cause": "1.2.2",
+        "tough-cookie": "2.3.3"
+      }
     },
     "portfinder": {
       "version": "1.0.13",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "autosuggest-highlight": "^3.1.1",
+    "client-oauth2": "^4.2.0",
     "immutable": "^3.8.2",
     "lodash": "^4.17.5",
     "material-ui": "^1.0.0-beta.36",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "react-visibility-sensor": "^3.11.0",
     "redux": "^3.7.2",
     "redux-api-middleware": "^2.3.0",
-    "redux-implicit-oauth2": "^1.2.1",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0"
   },

--- a/public/oauth2-callback.html
+++ b/public/oauth2-callback.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html><body><script>
+  (window.opener ? window.opener : window.parent).postMessage({
+    'type': 'oauth2Callback',
+    'location': {
+      'pathname': location.pathname, 'query': location.query,
+      'hash': location.hash
+    }
+  }, '*');
+</script></body></html>

--- a/scripts/create-client.sh
+++ b/scripts/create-client.sh
@@ -27,8 +27,8 @@ hydra clients create \
     --id testclient --is-public \
     --grant-types implicit \
     --response-types token,code,refresh_token \
-    --callbacks http://localhost:4445/callback,http://localhost:8000/static/iarbackend/oauth2-redirect.html,http://localhost:8080/static/lookupproxy/oauth2-redirect.html,http://localhost:3000/oauth2-callback \
-    --allowed-scopes lookup:anonymous,assetregister
+    --callbacks http://localhost:4445/callback,http://localhost:8000/static/iarbackend/oauth2-redirect.html,http://localhost:8080/static/lookupproxy/oauth2-redirect.html,http://localhost:3000/oauth2-callback,http://localhost:3000/oauth2-callback.html \
+    --allowed-scopes lookup:anonymous,assetregister,prompt:none
 
 # Create iarbackend client which can request scopes to access the lookup proxy
 # and to introspect tokens from hydra.

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,117 @@
+/**
+ * A basic OAuth2 implicit login client which supports interactive and non-interactive
+ * authorisation flows.
+ */
+import config from './config';
+import ClientOAuth2 from 'client-oauth2';
+
+/**
+ * OAuth2 credentials configuration for the IAR frontend application.
+ */
+const oauth2Config = {
+  clientId: config.oauth2ClientId,
+  authorizationUri: config.oauth2AuthEndpoint,
+  redirectUri: config.oauth2RedirectUrl,
+  scopes: config.oauth2Scopes,
+};
+
+/**
+ * Perform a login. Optionally takes a single options object with the following fields:
+ *
+ * prompt: Boolean, default true. Should the user be prompted if not logged in?
+ *
+ * If prompt is false, login is performed via a hidden IFrame. If prompt is true, a popup is used
+ * and so this should only be called as a result of a user action such as clicking a button.
+ *
+ * Returns a promise which is resolved on login or rejected with an error otherwise.
+ */
+export const login = ({ prompt=true } = {}) => {
+  const state = generateState();
+
+  // Create a new client-oauth2 client object with OAuth2 configuration from the global config.
+  const auth = new ClientOAuth2({
+    ...oauth2Config,
+    scopes: oauth2Config.scopes + (prompt ? '': ' prompt:none'),
+    state: state,
+  });
+
+  return new Promise((resolve, reject) => {
+    // if non-null, a function which clears up the resources created by the login
+    let cleanUp = null;
+
+    // Register an event listener which listens for the next message event and then unregisters
+    // itself.
+    const messageEventListener = event => {
+      if(!event || !event.data || event.data.type !== 'oauth2Callback') { return; }
+
+      // state has to be in the location hash for this to be meant for us
+      const uri = event.data.location;
+      if(!uri || !uri.hash || (uri.hash.indexOf(state) === -1)) { return; }
+
+      window.removeEventListener('message', messageEventListener);
+
+      // Clean up any UI elements
+      cleanUp();
+
+      // Parse the redirect URL content and resolve or reject the promise as appropriate.
+      auth.token.getToken(uri).then(resolve).catch(reject);
+    };
+    window.addEventListener('message', messageEventListener);
+
+    if(prompt) {
+      const newWindow = openPopup(
+        auth.token.getUri(), 'iar-sign-in', config.oauth2PopupWidth, config.oauth2PopupHeight
+      );
+      cleanUp = () => { newWindow.close(); }
+    } else {
+      const newFrame = openIFrame(auth.token.getUri());
+      cleanUp = () => { newFrame.remove(); }
+    }
+  });
+};
+
+// Utility functions
+
+/**
+ * Generate a random state (aka "nonce") used as part of the OAuth2 implicit flow.
+ */
+const generateState = function(length = 32) {
+  let text = '', possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  for(let i=0; i<length; i++) {
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  }
+  return text;
+};
+
+/**
+ * Open a hidden iframe pointing to the passed URL. Return the new iframe DOM element.
+ */
+const openIFrame = url => {
+  const iframe = document.createElement('iframe');
+  iframe.setAttribute('src', url)
+  iframe.style.display = 'none';
+  document.body.appendChild(iframe);
+  return iframe;
+};
+
+/**
+ * Open a popup window on the passed URL with a given name, width and height.
+ *
+ * Returns the new window object.
+ */
+const openPopup = (url, name, width, height) => {
+  const SETTINGS =
+      'scrollbars=no,toolbar=no,location=no,titlebar=no,directories=no,status=no,menubar=no'
+
+  const getPopupDimensions = (width, height) => {
+      const wLeft = window.screenLeft || window.screenX
+      const wTop = window.screenTop || window.screenY
+
+      const left = wLeft + window.innerWidth / 2 - width / 2
+      const top = wTop + window.innerHeight / 2 - height / 2
+
+      return `width=${width},height=${height},top=${top},left=${left}`
+  }
+
+  return window.open(url, name, `${SETTINGS},${getPopupDimensions(width, height)}`);
+};

--- a/src/config.js
+++ b/src/config.js
@@ -41,7 +41,7 @@ const config = {
 // If it hasn't previously been set, set the rdirect URL for OAuth2 implicit flow. We set it here
 // because "basename" may have been overridden by the reactAppConfiguration object.
 if(!config.oauth2RedirectUrl) {
-  config.oauth2RedirectUrl = window.location.origin + config.basename + 'oauth2-callback';
+  config.oauth2RedirectUrl = window.location.origin + config.basename + 'oauth2-callback.html';
 }
 
 export default config;

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -9,6 +9,7 @@ import {
 } from '../components';
 import PropTypes from 'prop-types';
 import AppRoutes from './AppRoutes';
+import TokenTimeout from './TokenTimeout';
 import theme from '../style/CustomMaterialTheme';
 import '../style/App.css';
 
@@ -35,6 +36,7 @@ const App = ({ store }) => (
           <Snackbar />
           <FetchSelf />
           <FetchLookupInstitutions />
+          <TokenTimeout />
         </div>
       </ReduxProvider>
     </IntlProvider>

--- a/src/containers/AppRoutes.js
+++ b/src/containers/AppRoutes.js
@@ -24,7 +24,6 @@ const AppRoutes = () => (
     <LoginRequiredRoute path="/feedback" exact component={() => <Static page='feedback' />}/>
     <LoginRequiredRoute path={NOT_A_USER_PATH} exact component={() => <Static page='no_permission' withSidebar={false} />}/>
 
-    <Route path="/oauth2-callback" exact component={() => <div />} />
     <LoginRequiredRoute path="/" exact component={RedirectToMyDeptAssets} />
 
     { /* Catch all route for "not found" */ }

--- a/src/containers/TokenTimeout.js
+++ b/src/containers/TokenTimeout.js
@@ -1,0 +1,228 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { login, logout, LOGIN_FAILURE } from '../redux/actions/auth';
+import { getSelf } from '../redux/actions/lookupApi';
+import { snackbarOpen } from '../redux/actions/snackbar';
+
+/**
+ * Instead of setting the token timeout exactly to the expiry time of the token, leave a little bit
+ * of "head room" so that we have a chance to act in good time before the token times out. This
+ * value is the number of milliseconds *before* token expiry at which our token expiration timer
+ * should fire.
+ *
+ * For testing purposes, this can be increased to near the total lifetime of the token. For
+ * normal use, we set it to 2 minutes which should be plenty of time.
+ */
+const TIMEOUT_HEAD_ROOM = 120e3; // milliseconds
+
+/**
+ * A component which manages a timer to handle token timeout.
+ *
+ * Just before the token times out (see note on "head room" above), attempt a prompt-less login. If
+ * this login fails, log the current user out.
+ *
+ * After a successful prompt-less login, we re-fetch the "self" resource and compare the identity
+ * returned with the first identity that was received by the application. If the self resource is
+ * for a different identity, we immediately log the user out. This is because we have no guarantee
+ * that the user who was logged in to the consent app when we first got an authorisation token is
+ * the same user that is logged in now. By comparing the self resource, we can check for ourselves
+ * that the logged in user has not changed.
+ *
+ * An example test protocol to check token timeout behaviour in development would be as follows:
+ *
+ * 1. Edit TIMEOUT_HEAD_ROOM to be 280e3. In development the access token lifetime if 5 minutes and
+ *    so this head room means that a new token should be fetched every 20 seconds.
+ *
+ * 2. To test token timeout behaviour, open http://localhost:8090/logout in another tab. This will
+ *    sign the current user out of the consent app and hence block prompt-less login. On the next
+ *    token refresh, the user should be logged out.
+ *
+ * 3. To test signing in as another user, open two IARs in two tabs: tab 1 and tab 2. Visit
+ *    http://localhost:8090/logout in tab 3. And sign in to the IAR in tab 1 as user test0010.
+ *    Switch to tab 3 and reload the logout URL. Then sign in to the IAR in tab 2. When IAR in tab
+ *    1 attempts token refresh, it should get a token for user test0011 and cause a logout.
+ */
+class TokenTimeout extends Component {
+  constructor(...args) {
+    super(...args);
+
+    // Value returned by setTimeout. If non-NULL, the corresponding timeout is still "in flight".
+    this.timeoutID = null;
+
+    // Cached auth token. If this changes, the self resource will be re-fetched to check that it
+    // still corresponds to the original identity.
+    this.authToken = null;
+
+    // Cached expiry time for the token.
+    this.expiresAt = null;
+
+    // The first self resource we ever see. If the self resource ever changes identity from this,
+    // log the user out.
+    this.firstSelf = null;
+  }
+
+  componentDidMount() {
+    const { auth, self } = this.props;
+
+    // If this component is mounted after we already have an auth, we won't get a
+    // componentWillReceiveProps call so handle the current auth, whatever it is.
+    this.handleProps(auth, self);
+  }
+
+  componentWillUnmount() {
+    // On unmount, clear any cached state and remove the timer if it is in flight
+
+    if(this.timeoutID !== null) {
+      window.clearTimeout(this.timeoutID);
+      this.timeoutID = null;
+    }
+    this.authToken = this.expiresAt = this.firstSelf = null;
+  }
+
+  handleProps(auth, self) {
+    const { logout, getSelf, snackbarOpen } = this.props;
+
+    // If the user has logged out by some other means, cancel any timeout which may be pending and
+    // clear all cached state. There is a small race here in that the timer may fire before we get
+    // notified about the log out so the timeout function also makes this same check.
+    if(!auth.isLoggedIn || !auth.token) {
+      if(this.timeoutID !== null) {
+        window.clearTimeout(this.timeoutID);
+        this.timeoutID = null;
+      }
+
+      // Reset state
+      this.authToken = this.expiresAt = this.firstSelf = null;
+
+      // There is no further work to do if the user has logged out.
+      return;
+    }
+
+    // If this is the first auth token we've seen, cache it.
+    if(!this.authToken && auth.token) {
+      this.authToken = auth.token;
+    }
+
+    // If this is the first self resource we've seen, cache it.
+    if(!this.firstSelf && self) {
+      this.firstSelf = self;
+    }
+
+    // If self ever changes, we need to logout!
+    if(this.firstSelf && self && !selvesAreTheSame(this.firstSelf, self)) {
+      console.error('Became someone else after re-login');
+      logout();
+
+      // This has to be *after* logout because state (including snackbar state) is reset after
+      // logout.
+      snackbarOpen('Someone else has signed in in another browser window.');
+      return;
+    }
+
+    // If the access token has changed and we have a cached self resource, dispatch a getSelf
+    // action. The new self resource will be checked on the next call to handleProps.
+    if(this.firstSelf && auth.token && this.authToken && (this.authToken !== auth.token)) {
+      getSelf();
+    }
+
+    // If the access token has changed, update our cache. It is important to do this *after* all
+    // the checks above which compare this.authToken and auth.token.
+    if(this.authToken !== auth.token) {
+      this.authToken = auth.token;
+    }
+
+    // If expiresAt has changed, update our timeout.
+    if(this.expiresAt !== auth.expiresAt) {
+      this.expiresAt = auth.expiresAt;
+
+      // Cancel any existing timeout.
+      if(this.timeoutID !== null) {
+        window.clearTimeout(this.timeoutID);
+        this.timeoutID = null;
+      }
+
+      // Calculate the timeout delay from the token expiry time.
+      const now = (new Date()).getTime();
+      const timeoutDelay = auth.expiresAt - now - TIMEOUT_HEAD_ROOM;
+
+      // Sanity check the delay. If it is in the past, immediately log the user out and log a
+      // warning to explain ourselves.
+      if(timeoutDelay < 0) {
+        console.warn('Token had very short timeout.');
+        console.warn('Expires at ' + new Date(auth.expiresAt));
+        console.warn('Now is ' + new Date(now));
+        console.warn('Head room ' + TIMEOUT_HEAD_ROOM / 1000 + ' seconds');
+        console.warn('Would therefore fire at ' + new Date(timeoutDelay + now));
+
+        // token has therefore already timed out, just log out
+        logout();
+        return;
+      }
+
+      // Register the new timeout.
+      this.timeoutID = window.setTimeout(() => this.handleTimeout(), timeoutDelay);
+    }
+  }
+
+  // Called before the token times out. Log the user in again.
+  handleTimeout() {
+    // extract auth state and actions from props
+    const { auth, login, logout, snackbarOpen } = this.props;
+
+    // Don't do anything if we're already logged out. The timeout *should* have been cancelled
+    // already but it makes sense to be sure with this many moving parts.
+    if(!auth.isLoggedIn) { return; }
+
+    // Attempt prompt-less login. Login is an RSAA-style action and when dispatched returns a
+    // Promise resolved with the final FSA-style action.
+    login({ prompt: false })
+      .then(action => {
+        const { type } = action;
+
+        // As long as the login didn't fail, we're happy.
+        if(type !== LOGIN_FAILURE) { return action; }
+
+        // On failure we log the error to the console and log the user out.
+        console.error('Error doing prompt-less login');
+        console.error(action.payload.error);
+        logout();
+
+        // This has to be *after* logout because state (including snackbar state) is reset after
+        // logout.
+        snackbarOpen('Your session has timed out.');
+
+        return action;
+      });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { auth, self } = nextProps;
+    this.handleProps(auth, self);
+  }
+
+  render() { return null; }
+};
+
+TokenTimeout.propTypes = {
+  auth: PropTypes.shape({
+    isLoggedIn: PropTypes.bool.isRequired,
+    expiresAt: PropTypes.number,
+  }).isRequired,
+  login: PropTypes.func.isRequired,
+  logout: PropTypes.func.isRequired,
+  getSelf: PropTypes.func.isRequired,
+  snackbarOpen: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ auth, lookupApi: { self } }) => ({ auth, self });
+
+TokenTimeout = connect(mapStateToProps, { login, logout, getSelf, snackbarOpen })(TokenTimeout);
+
+export default TokenTimeout;
+
+// Compare the identities of two self resources for equality.
+const selvesAreTheSame = (a, b) => (
+  (a.identifier.scheme === b.identifier.scheme) &&
+  (a.identifier.value === b.identifier.value)
+);

--- a/src/containers/TokenTimeout.js
+++ b/src/containers/TokenTimeout.js
@@ -31,7 +31,7 @@ const TIMEOUT_HEAD_ROOM = 120e3; // milliseconds
  *
  * An example test protocol to check token timeout behaviour in development would be as follows:
  *
- * 1. Edit TIMEOUT_HEAD_ROOM to be 280e3. In development the access token lifetime if 5 minutes and
+ * 1. Edit TIMEOUT_HEAD_ROOM to be 280e3. In development the access token lifetime is 5 minutes and
  *    so this head room means that a new token should be fetched every 20 seconds.
  *
  * 2. To test token timeout behaviour, open http://localhost:8090/logout in another tab. This will

--- a/src/redux/actions/auth.test.js
+++ b/src/redux/actions/auth.test.js
@@ -1,0 +1,41 @@
+jest.mock('../../auth');
+
+import { login, LOGIN_SUCCESS, LOGIN_FAILURE } from './auth';
+import { login as authLogin } from '../../auth';
+
+describe('login', () => {
+  let dispatch;
+
+  beforeEach(() => {
+    authLogin.mockReset();
+    authLogin.mockImplementation(() => Promise.resolve('some-token'));
+    dispatch = jest.fn(action => action);
+  });
+
+  test('passes options to auth.login', () => {
+    const options = { prompt: true };
+    login(options)(dispatch);
+    expect(authLogin).toHaveBeenCalledTimes(1);
+    expect(authLogin).toHaveBeenCalledWith(options);
+  });
+
+  test('returns promise resolved with LOGIN_SUCCESS action if login succeeds', () => {
+    const options = { prompt: true }, token = 'new-token';
+    authLogin.mockImplementation(() => Promise.resolve(token));
+    const authPromise = login(options)(dispatch);
+    expect(authPromise).toBeInstanceOf(Promise);
+    expect(login(options)(dispatch)).resolves.toMatchObject({
+      type: LOGIN_SUCCESS, payload: { token }
+    });
+  });
+
+  test('returns promise resolved with LOGIN_FAILURE action if login succeeds', () => {
+    const options = { prompt: true }, error = 'do-not-like-you';
+    authLogin.mockImplementation(() => Promise.reject(error));
+    const authPromise = login(options)(dispatch);
+    expect(authPromise).toBeInstanceOf(Promise);
+    expect(login(options)(dispatch)).resolves.toMatchObject({
+      type: LOGIN_FAILURE, payload: { error }
+    });
+  });
+});

--- a/src/redux/enhancer.js
+++ b/src/redux/enhancer.js
@@ -1,11 +1,10 @@
 import { applyMiddleware } from 'redux';
-import { authMiddleware as auth } from 'redux-implicit-oauth2';
 import { apiMiddleware as api } from 'redux-api-middleware';
 import { apiAuth, netError } from './middlewares';
 import logger from 'redux-logger';
 import thunk from 'redux-thunk';
 
-export const middlewares = [thunk, auth, apiAuth, netError, api];
+export const middlewares = [thunk, apiAuth, netError, api];
 
 // only add logger middleware in development
 if (process.env.NODE_ENV === 'development') {

--- a/src/redux/reducers/auth.js
+++ b/src/redux/reducers/auth.js
@@ -1,0 +1,92 @@
+import { LOGIN_REQUEST, LOGIN_SUCCESS, LOGIN_FAILURE, LOGOUT } from '../actions/auth';
+
+export const AUTH_TOKEN_STORAGE_KEY = 'cachedOAuth2TokenData';
+
+// Update initial state based upon any token saved in the localStorage
+export const retrieveStoredToken = state => {
+  // no localStorage support in browser?
+  if(!window.localStorage) { return state; }
+
+  // is there any stored data?
+  const storedTokenJSON = window.localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+  if(!storedTokenJSON) { return state; }
+
+  // attempt to parse it as JSON
+  let storedToken;
+  try {
+    storedToken = JSON.parse(storedTokenJSON);
+  } catch(err) {
+    // we silently swallow the error here to avoid polluting the console but we could report it
+    // via, for example:
+    // console.error(err);
+    return state;
+  }
+
+  // extract token data
+  const { token, expiresAt } = storedToken;
+
+  // is the token still alive?
+  if(!token || !expiresAt || expiresAt < (new Date()).getTime()) { return state; }
+
+  // everything checks out, retrieve it
+  return { ...state, isLoggedIn: true, token, expiresAt };
+};
+
+// Save access token to localStorage
+const saveStoredToken = (token, expiresAt) => {
+  // no localStorage support in browser?
+  if(!window.localStorage) { return; }
+  window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, JSON.stringify({ token, expiresAt }));
+};
+
+// Remove any access token cached in local storage.
+const clearStoredToken = () => {
+  // no localStorage support in browser?
+  if(!window.localStorage) { return; }
+  window.localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+}
+
+// The initial state is passed through retrieveStoredToken which sets the token, expiresAt and
+// isLoggedIn fields if there is a valid token saved in the browser's local storage.
+export const initialState = retrieveStoredToken({
+  // Current access token for user or null if there is not one.
+  token: null,
+
+  // If non-null, the last login error.
+  error: null,
+
+  // If true, the user is currently logging in.
+  isLoggingIn: false,
+
+  // If true, the user is currently logged in.
+  isLoggedIn: false,
+
+  // A timestamp (as returned by Date.getTime()) indicating when the token expires.
+  expiresAt: null,
+});
+
+export default (state = initialState, action) => {
+  switch(action.type) {
+    case LOGIN_REQUEST:
+      return {...state, isLoggingIn: true };
+    case LOGIN_SUCCESS:
+      {
+        // extract the authorisation token from the action's payload
+        const { token: tokenObject } = action.payload;
+        const token = tokenObject.accessToken, expiresAt = tokenObject.expires.getTime();
+
+        // cache the token in the browser's localStorage
+        saveStoredToken(token, expiresAt);
+
+        return { ...state, isLoggingIn: false, isLoggedIn: true, token, expiresAt };
+      }
+    case LOGIN_FAILURE:
+      return {...state, isLoggingIn: false, isLoggedIn: false, token: null, expiresAt: null};
+    case LOGOUT:
+      // clear any cached token from localStorage
+      clearStoredToken();
+      return {...state, isLoggedIn: false, token: null, expiresAt: null};
+    default:
+      return state;
+  }
+}

--- a/src/redux/reducers/auth.test.js
+++ b/src/redux/reducers/auth.test.js
@@ -1,0 +1,116 @@
+// mock window.localStorage
+import '../../test/mock-localstorage';
+
+import reducer, { AUTH_TOKEN_STORAGE_KEY, retrieveStoredToken } from './auth';
+import { LOGIN_REQUEST, LOGIN_SUCCESS, LOGIN_FAILURE, LOGOUT } from '../actions/auth';
+
+describe('LOGIN_REQUEST', () => {
+  test('sets isLoggingIn', () => {
+    const state = reducer(undefined, { type: LOGIN_REQUEST });
+    expect(state.isLoggingIn).toBe(true);
+  });
+});
+
+describe('LOGIN_SUCCESS', () => {
+  let action, state;
+
+  beforeEach(() => {
+    // make sure local storage is clear
+    window.localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+
+    action = {
+      type: LOGIN_SUCCESS, payload: { token: { accessToken: 'xxx', expires: new Date() } }
+    };
+
+    state = reducer(undefined, action);
+  });
+
+  test('sets isLoggedIn', () => {
+    expect(state.isLoggedIn).toBe(true);
+  });
+
+  test('sets token', () => {
+    expect(state.token).toBe(action.payload.token.accessToken);
+  });
+
+  test('sets expiresAt', () => {
+    expect(state.expiresAt).toBe(action.payload.token.expires.getTime());
+  });
+
+  test('clears isLoggingIn', () => {
+    expect(state.isLoggingIn).toBe(false);
+  });
+
+  test('stores state', () => {
+    window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, JSON.stringify({
+      token: action.payload.token.accessToken, expiresAt: action.payload.token.expires.getTime()
+    }));
+
+    // now initial state should find the token cached
+    const newInitialState = retrieveStoredToken(reducer(undefined, { }));
+    expect(newInitialState).toMatchObject({
+      token: action.payload.token.accessToken,
+      expiresAt: action.payload.token.expires.getTime(),
+    });
+  });
+});
+
+describe('LOGIN_FAILURE', () => {
+  let action, state;
+
+  beforeEach(() => {
+    action = {
+      type: LOGIN_FAILURE, payload: { error: 'xxx' }
+    };
+    state = reducer(undefined, action);
+  });
+
+  test('clears isLoggingIn', () => {
+    expect(state.isLoggingIn).toBe(false);
+  });
+
+  test('clears isLoggedIn', () => {
+    expect(state.isLoggedIn).toBe(false);
+  });
+
+  test('clears token', () => {
+    expect(state.token).toBe(null);
+  });
+
+  test('clears expiresAt', () => {
+    expect(state.expiresAt).toBe(null);
+  });
+});
+
+describe('LOGOUT', () => {
+  let action, state;
+
+  beforeEach(() => {
+    window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, 'xxx');
+    action = { type: LOGOUT };
+    state = reducer(undefined, action);
+  });
+
+  test('clears isLoggedIn', () => {
+    expect(state.isLoggedIn).toBe(false);
+  });
+
+  test('clears token', () => {
+    expect(state.token).toBe(null);
+  });
+
+  test('clears expiresAt', () => {
+    expect(state.expiresAt).toBe(null);
+  });
+
+  test('clears stored token', () => {
+  });
+});
+
+describe('retrieveStoredToken', () => {
+  test('returns its input if stored state invalid', () => {
+    window.localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, 'not-some-json');
+    const initialState = reducer(undefined, {});
+    expect(retrieveStoredToken(initialState)).toBe(initialState);
+  });
+});

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -1,12 +1,12 @@
 import { combineReducers } from 'redux';
-import { authReducer as auth } from 'redux-implicit-oauth2';
+import auth from './auth';
 import assets from './assetRegisterApi';
 import deleteConfirmation from './deleteConfirmation';
 import snackbar from './snackbar';
 import lookupApi from './lookupApi';
 import editAsset from './editAsset';
 
-import { LOGOUT } from 'redux-implicit-oauth2';
+import { LOGOUT } from '../actions/auth';
 
 /**
  * Combine all reducers used in the application together into one reducer.

--- a/src/redux/reducers/index.test.js
+++ b/src/redux/reducers/index.test.js
@@ -11,7 +11,7 @@ jest.mock('redux', () => {
 
 import { combineReducers } from 'redux';
 import wrappedReducers, { reducers } from './index';
-import { LOGOUT } from 'redux-implicit-oauth2';
+import { LOGOUT } from '../actions/auth';
 
 const mockReducers = combineReducers();
 

--- a/src/redux/reducers/snackbar.js
+++ b/src/redux/reducers/snackbar.js
@@ -10,7 +10,7 @@ export default (state = initialState, action) => {
     case SNACKBAR_OPEN:
       return { ...state, isOpen: true, message: action.payload.message };
     case SNACKBAR_CLOSE:
-      return { ...state, isOpen: false, message: '' };
+      return { ...state, isOpen: false };
     default:
       return state;
   }

--- a/src/test/mock-localstorage.js
+++ b/src/test/mock-localstorage.js
@@ -1,7 +1,7 @@
 /**
  * Import this module to mock the global window.localStorage object.
  *
- * The redux-implicit-oauth2 package examines localStorage when first run to determine if there is
+ * The implicit OAuth2 implmentation examines localStorage when first run to determine if there is
  * any OAuth2 token defined for the app.
  */
 import localStorage from 'mock-local-storage';


### PR DESCRIPTION
This PR addresses #98 and has the following dependent PRs:

* uisautomation/hydra-consent-app#5
* uisautomation/experimental-mock-consent-app#2
* uisautomation/iar-deploy#31

It is quite a large PR and is best reviewed commit-wise since most commits have somewhat involved comments.

The main body of the PR is composed of two commits, 6c6e3af and 5dc698e.

6c6e3af replaces our existing use of ``redux-implicit-oauth2`` with our own version of implicit OAuth2 flow (implemented in 86ecd15) which distinguishes between normal and "promptless" logins. The latter logins do not require a popup window but may fail.

5dc698e makes use of the new OAuth2 login implemented by 6c6e3af in order to provide a nicer UX on token timeout. See that commit's comment for more information. The commit itself includes notes on how it may be tested.

Since token timeout behaviour rarely appears in development, 87deb90 takes the opportunity to configure the access token lifetime in development to be 5 minutes. This is done in the hope that such a short lifetime will quickly surface token timeout problems.

78b2b6e fixes a small visual bug with snackbars discovered during the implementation of 5dc698e.

Some aspects of this PR are a little under-tested. 5dc698e and 86ecd15 are particular examples of this. The problem is that both essentially rely on the behaviour of the browser. The former performs tricks with timeouts and the latter performs tricks with the window object. They would be better tested with a full browser environment but our test suite does not currently provide that. In lieu of automated testing, 5dc698e contains a description of a procedure which can be used to test both token timeout failure modes.

Closes #98