### PR TITLE
hack: limit length of text input

### DIFF
--- a/src/AssetDetail/presentational/GeneralInformationFields.js
+++ b/src/AssetDetail/presentational/GeneralInformationFields.js
@@ -34,6 +34,7 @@ const GeneralInformationFields = ({ component: Component = 'div', classes, ...re
             "Give the asset a unique name so you can easily identify it, for example, " +
             "'Visiting academics database'. If your institution has sub-divisions, or is part of the Academic Division you should reference that too, eg ‘(Student Registry) HR Records’."
           }
+          inputProps={{maxlength: 240}}  // HACK: until 400 handling is better
         />
       </Grid>
       <Grid item xs={6} />
@@ -63,6 +64,7 @@ const GeneralInformationFields = ({ component: Component = 'div', classes, ...re
             // goes.
             "\xa0"
           }
+          inputProps={{maxlength: 240}}  // HACK: until 400 handling is better
         >
           {PURPOSE_LABELS.map(({ value, label }) => (
             <MenuItem key={value} value={value}>{ label }</MenuItem>

--- a/src/AssetDetail/presentational/RiskFields.js
+++ b/src/AssetDetail/presentational/RiskFields.js
@@ -57,6 +57,7 @@ const RiskFields = ({ component: Component = 'div', classes, ...rest }) => (
           multiline
           label="Supporting information"
           helperText="Please tell us a bit more detail about why these risks exist and how it could impact your institution or the University"
+          inputProps={{maxlength: 240}}  // HACK: until 400 handling is better
         />
       </Grid>
     </Grid>

--- a/src/AssetDetail/presentational/StorageAndSecurityFields.js
+++ b/src/AssetDetail/presentational/StorageAndSecurityFields.js
@@ -36,6 +36,7 @@ const StorageAndSecurityFields = ({ component: Component = 'div', classes, ...re
           helperText={
             "List all the places you store it — for example in Room 45, Greenwich House; on a server in West Cambridge; in  [name of team] Dropbox."
           }
+          inputProps={{maxlength: 240}}  // HACK: until 400 handling is better
         />
       </Grid>
       <Grid item xs={6} />


### PR DESCRIPTION
The backend requires that text input be less than 255 characters but nothing on the frontend mandates this. As a hack, limit all text fields to 240 characters.

We need to revisit this later for a better solution.

This issue is being hit by users in the wild.